### PR TITLE
DTGB-130: Added hook to display webform help text as field-description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
+## unreleased
+* DTGB-130: display webform help text as field-description.
+
 ## gent_base-8.x-1.1-alpha8
 **Updated to gent_styleguide version 2.7.7**
 

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -232,3 +232,22 @@ function gent_base_preprocess_element_information(&$variables) {
     $variables['information']['content'] = $element['#information'];
   }
 }
+
+/**
+ * Implements hook_preprocess_form_element().
+ */
+function gent_base_preprocess_form_element(&$variables) {
+  $element = &$variables['element'];
+  if (!isset($element['#help'])) {
+    return;
+  }
+
+  $element['#information'] = $element['#help'];
+}
+
+/**
+ * Implements hook_preprocess_webform_element_help().
+ */
+function gent_base_preprocess_webform_element_help(&$variables) {
+  $variables['help_icon'] = NULL;
+}


### PR DESCRIPTION
Tested in WONDER https://bitbucket.org/digipolisgent/drupal8_site_scholen/commits/f5753228ee97c434bf2265c9f7e77f3281f4fb92?at=develop