### PR TITLE
Feature/DTGB-398: Updated version_tag deployment script for 8.x-3.x branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
 * **IMPORTANT** Integrate style guide in this project for an easier workflow.
 
+## gent_base-8.x-2.10
+
+* DTGB-140: ** IMPORTANT: Merged the style guide in the gent_base theme.**
+
 ## gent_base-8.x-1.1-alpha9
 
 * DTGB-133: Fixed styling of messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
-## Unreleased
+## gent_base-8.x-3.0
 
-* **IMPORTANT** Integrate style guide in this project for an easier workflow.
+* DTGB-398: Updated version_tag.sh script for easier deployment. 
 
 ## gent_base-8.x-2.10
 

--- a/scripts/version_tag.sh
+++ b/scripts/version_tag.sh
@@ -4,14 +4,13 @@
 #
 #          FILE:  version_tag.sh
 #
-#         USAGE:  ./version_tag.sh --type=patch
-#                 ./version_tag.sh --type=minor
+#         USAGE:   ./version_tag.sh --type=minor
 #                 ./version_tag.sh --type=major
 #
 #   DESCRIPTION:  ONLY USABLE FOR DIGIPOLIS EMPLOYEES!
-#                 This script automatically pulls in the latest origin/develop into your local development branch,
-#                 updates the version number based on the --type parameter and merges the development branch in the
-#                 master branch before tagging and pushing to git. Jenkins does the rest.
+#                 This script automatically pulls in the latest origin/8.x-3.x-dev into your local development branch,
+#                 updates the version number based on the --type parameter and merges the 8.x-3.x-dev branch in the
+#                 8.x-3.x branch before tagging and pushing to git. Jenkins does the rest.
 #
 #       OPTIONS:  --type
 #  REQUIREMENTS:  ---
@@ -19,10 +18,14 @@
 #         NOTES:  ---
 #        AUTHOR:  Gert-Jan Meire, gertjan.meire@digipolis.gent
 #       COMPANY:  Digipolis Gent
-#       VERSION:  1.0
+#       VERSION:  2.0
 #       CREATED:  12/12/2017
 #      REVISION:  ---
 #===============================================================================
+
+echo 'Move to the gent_base root directory...';
+cd ../;
+pwd;
 
 # Check if git is installed on your system.
 if ! [ -x "$(command -v git)" ]; then
@@ -32,8 +35,12 @@ fi
 
 # Get latest changes in git.
 echo "Checking out latest development changes...";
-git checkout develop;
+git checkout 8.x-3.x-dev;
 git pull;
+
+echo 'Move to the styleguide directory...';
+cd styleguide
+pwd;
 
 # Check if gulp validates, otherwise terminate the script.
 gulp validate
@@ -54,7 +61,7 @@ gulp build
 # Check if type argument is not empty.
 if [ $# -eq 0 ]
   then
-    echo "No arguments supplied. Please provide a type parameter like -t=patch."
+    echo "No arguments supplied. Please provide a type parameter like -t=minor."
     exit 1
 fi
 
@@ -74,24 +81,32 @@ echo "Updating version...";
 gulp bump --type=$TYPE
 
 # Get the new package version.
-PACKAGE_VERSION=$(cat package.json \
+SEMANTIC_PACKAGE_VERSION=$(cat package.json \
   | grep version \
   | head -1 \
   | awk -F: '{ print $2 }' \
   | sed 's/[",]//g' \
   | tr -d '[[:space:]]')
 
+PACKAGE_VERSION=${SEMANTIC_PACKAGE_VERSION%.*}
+TAG='8.x-'$PACKAGE_VERSION
+
 echo $PACKAGE_VERSION
+echo $TAG
+
+echo 'Move to the gent_base root directory...';
+cd  ../;
+pwd
 
 # Add everything to git.
 echo "Adding changes to git and tagging "$PACKAGE_VERSION
 git add *
 git commit -m "Updated to version "$PACKAGE_VERSION
 echo "Checking out master branch... and pushing develop in master..."
-git checkout master
+git checkout 8.x-3.x
 git pull
-git merge develop
-git tag $PACKAGE_VERSION
+git merge 8.x-3.x-dev
+git tag $TAG
 
 # Deploy to git.
 echo "Pushing master and develop branches to remote..."

--- a/scripts/version_tag.sh
+++ b/scripts/version_tag.sh
@@ -92,8 +92,22 @@ SEMANTIC_PACKAGE_VERSION=$(cat package.json \
   | sed 's/[",]//g' \
   | tr -d '[[:space:]]')
 
-PACKAGE_VERSION=${SEMANTIC_PACKAGE_VERSION%.*}
-TAG='8.x-'$PACKAGE_VERSION
+# If the new version of the package is a prerelease version we should adapt the
+# gent_base tab accordingly as an alpha release.
+# F.e. 2.3.0-1 (semantic versioning) should become 2.3-alpha1
+if [[ $TYPE == *"prerelease"* ]]
+then
+  echo 'Creating prerelease git tag...';
+  PRERELEASE_VERSION=${SEMANTIC_PACKAGE_VERSION#*-}
+  PACKAGE_VERSION=${SEMANTIC_PACKAGE_VERSION%.*}
+  TAG='8.x-'$PACKAGE_VERSION'-alpha'$PRERELEASE_VERSION
+else
+  echo 'Creating git tag...'
+  PACKAGE_VERSION=${SEMANTIC_PACKAGE_VERSION%.*}
+  TAG='8.x-'$PACKAGE_VERSION
+fi
+
+echo "Created git tag $TAG"
 
 echo 'Move to the gent_base root directory...';
 cd  ../;

--- a/scripts/version_tag.sh
+++ b/scripts/version_tag.sh
@@ -8,9 +8,12 @@
 #                 ./version_tag.sh --type=major
 #
 #   DESCRIPTION:  ONLY USABLE FOR DIGIPOLIS EMPLOYEES!
-#                 This script automatically pulls in the latest origin/8.x-3.x-dev into your local development branch,
-#                 updates the version number based on the --type parameter and merges the 8.x-3.x-dev branch in the
-#                 8.x-3.x branch before tagging and pushing to git. Jenkins does the rest.
+#                 This script automatically pulls in the latest
+#                 origin/8.x-3.x-dev branch, updates the version number based
+#                 on the --type parameter and merges the 8.x-3.x-dev branch
+#                 in the 8.x-3.x branch before tagging and pushing to git.
+#                 Jenkins then splits the styleguide directory into its own
+#                 git repo and publishes a new NPM version of the style guide.
 #
 #       OPTIONS:  --type
 #  REQUIREMENTS:  ---
@@ -23,15 +26,22 @@
 #      REVISION:  ---
 #===============================================================================
 
-echo 'Move to the gent_base root directory...';
-cd ../;
-pwd;
-
 # Check if git is installed on your system.
 if ! [ -x "$(command -v git)" ]; then
   echo 'Error: git is not installed.' >&2
   exit 1
 fi
+
+# Check if type argument is not empty.
+if [ $# -eq 0 ]
+  then
+    echo "No arguments supplied. Please provide a type parameter like -t=minor."
+    exit 1
+fi
+
+echo 'Move to the gent_base root directory...';
+cd ../;
+pwd;
 
 # Get latest changes in git.
 echo "Checking out latest development changes...";
@@ -58,13 +68,6 @@ fi
 #echo "Building latest style guide version...";
 gulp build
 
-# Check if type argument is not empty.
-if [ $# -eq 0 ]
-  then
-    echo "No arguments supplied. Please provide a type parameter like -t=minor."
-    exit 1
-fi
-
 # Checking for type argument.
 for i in "$@"
   do
@@ -76,7 +79,8 @@ for i in "$@"
     esac
 done
 
-# Update the version based on the argument given (patch, minor, major) using our gulp bump command.
+# Update the version based on the argument given (patch, minor, major)
+# using our gulp bump command.
 echo "Updating version...";
 gulp bump --type=$TYPE
 
@@ -91,9 +95,6 @@ SEMANTIC_PACKAGE_VERSION=$(cat package.json \
 PACKAGE_VERSION=${SEMANTIC_PACKAGE_VERSION%.*}
 TAG='8.x-'$PACKAGE_VERSION
 
-echo $PACKAGE_VERSION
-echo $TAG
-
 echo 'Move to the gent_base root directory...';
 cd  ../;
 pwd
@@ -105,7 +106,7 @@ git commit -m "Updated to version "$PACKAGE_VERSION
 echo "Checking out master branch... and pushing develop in master..."
 git checkout 8.x-3.x
 git pull
-git merge 8.x-3.x-dev
+git merge --no-ff 8.x-3.x-dev
 git tag $TAG
 
 # Deploy to git.

--- a/styleguide/CHANGELOG.md
+++ b/styleguide/CHANGELOG.md
@@ -8,6 +8,12 @@ Refer to upcoming changes in our README.md under "Roadmap"
 
 All notable changes to this style guide are documented here.
 
+### 2.10.0
+
+* DTGB-140: Removed some files from the NPM package.
+* DTGB-140: Fixed a bug where `npm install` breaks 
+  the install of the style guide.
+
 ### 2.9.0
 
 * STIJ-246: Added a mixin  and class `no-link-style` to make it possible

--- a/styleguide/CHANGELOG.md
+++ b/styleguide/CHANGELOG.md
@@ -8,6 +8,11 @@ Refer to upcoming changes in our README.md under "Roadmap"
 
 All notable changes to this style guide are documented here.
 
+### 3.0.0
+
+* DTGB-398: Moved `version_tag.sh` script from the style guide to 
+  the gent_base `scripts` directory.
+
 ### 2.10.0
 
 * DTGB-140: Removed some files from the NPM package.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This script works for the 8.x-3.x-dev and 8.x-3.x branches and automatically bumps the package.json version number, then merges 8.x-3.x-dev in 8.x-3.x and tags with the correct tag number.

Due to the changes to gent_base and the styleguide it updates the package.json with a semantic versioning number like 3.1.0 but it creates a git tag lie 8.x-3.1


## Motivation and Context
Make deploying from dev to master easier + automates the tagging to publish a new style guide version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the style guide CHANGELOG accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
