### PR TITLE
Feature/DTGB-407: Changed default font size breakpoints.

### DIFF
--- a/styleguide/CHANGELOG.md
+++ b/styleguide/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this style guide are documented here.
 > Did some refactoring to the SASS partials. Most of the input field styling
 > can now be found in the `_forms.scss` partial.
 
+* DTGB-407: Changed the default font size breakpoints.
 
 ### 2.11.0
 

--- a/styleguide/components/00-settings/_vars.scss
+++ b/styleguide/components/00-settings/_vars.scss
@@ -49,17 +49,6 @@ $border-radius: (
 ) !default;
 
 ///
-/// Defines the breakpoint for fonts on tablets.
-///
-/// @since 3.0.0
-/// @group settings
-/// @access public
-/// @type string
-/// @author Gert-Jan Meire
-///
-$bp-tablet-fonts: 640px !default;
-
-///
 /// Defines the breakpoint for fonts on desktop.
 ///
 /// @since 3.0.0
@@ -68,7 +57,7 @@ $bp-tablet-fonts: 640px !default;
 /// @type string
 /// @author Gert-Jan Meire
 ///
-$bp-desktop-fonts: 1360px !default;
+$bp-desktop-xl-fonts: 1920px !default;
 
 ///
 /// Defines the min-width breakpoint for mobile screens.

--- a/styleguide/components/11-base/base/_base.scss
+++ b/styleguide/components/11-base/base/_base.scss
@@ -14,11 +14,7 @@ html {
   line-height: $default-line-height;
   box-sizing: border-box;
 
-  @include breakpoint($bp-tablet-fonts) {
-    font-size: $default-font-size + 2;
-  }
-
-  @include breakpoint($bp-desktop-fonts) {
+  @include breakpoint($bp-desktop-xl-fonts) {
     font-size: $default-font-size + 4;
   }
 }

--- a/styleguide/components/11-base/fonts/fonts.twig
+++ b/styleguide/components/11-base/fonts/fonts.twig
@@ -1,8 +1,7 @@
 <h4 class="styleguide-title">{{ 'Fonts' }}</h4>
 <div class="preview-inner-container styleguide-secondary-colors">
-  <p>{{ 'Base font-size (mobile, until 680px): 16px'}}</p>
-  <p>{{ 'Base font-size (tablet, small desktop, until 1360px): 18px'}}</p>
-  <p>{{ 'Base font-size (large desktop, starting from 1360px): 20px'}}</p>
+  <p>{{ 'Base font-size (mobile, until 1920px): 16px'}}</p>
+  <p>{{ 'Base font-size (large desktop, starting from 1920px): 20px'}}</p>
 
   <p>{{ 'Elements that deviate from these values are to be scaled with rems.'}}</p>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As defined by design we changed the font size breakpoints to always have default font size 16px (1rem) until  the screen resolution becomes 1920 or larger, then it becomes 20px.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the style guide CHANGELOG accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
