### PR TITLE
[DTGB-466] Links met een icoon worden niet correct gecentreerd wnr deze start met https:// en standalone-link is.

### DIFF
--- a/styleguide/components/21-atoms/link/_link.scss
+++ b/styleguide/components/21-atoms/link/_link.scss
@@ -115,10 +115,10 @@ a {
   &[download]:not(.button),
   &[href^="http://"]:not(.button),
   &[href^="https://"]:not(.button) {
-    display: inline-block;
+    display: inline-flex;
 
     &::after {
-      display: inline-block;
+      display: block;
       text-decoration: none;
     }
   }


### PR DESCRIPTION
# Ticket
Link to ticket: https://digipolisgent.atlassian.net/browse/DTGB-466