### PR TITLE
DTGB-506: Added support for titles in paragraphs.

### DIFF
--- a/templates/contrib/paragraphs/image-gallery/paragraph--image.html.twig
+++ b/templates/contrib/paragraphs/image-gallery/paragraph--image.html.twig
@@ -1,7 +1,48 @@
+{#
+/**
+ * @file
+ * Theme implementation to display an image gallery paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+
 {% extends 'paragraph.html.twig' %}
 
 {% block content %}
   <div class="image-gallery--wrapper">
-    {{ content }}
+    {{ content|without('field_title') }}
   </div>
 {% endblock %}

--- a/templates/contrib/paragraphs/paragraph.html.twig
+++ b/templates/contrib/paragraphs/paragraph.html.twig
@@ -3,6 +3,13 @@
  * @file
  * Default theme implementation to display a paragraph.
  *
+ * This template supports the field_title on the paragraphs.
+ *
+ * The paragraphs templates support a paragraph field_title field using the
+ * heading field type (@see https://www.drupal.org/project/heading).
+ * The heading field type allows adding a text title and selecting the heading
+ * size.
+ *
  * Available variables:
  * - paragraph: Full paragraph entity.
  *   Only method names starting with "get", "has", or "is" and a few common
@@ -40,7 +47,12 @@
 #}
 
 {% block paragraph %}
+  {% block title %}
+    {% if content.field_title|render|striptags|trim is not empty %}
+      {{ content.field_title }}
+    {% endif %}
+  {% endblock %}
   {% block content %}
-    {{ content }}
+    {{ content|without('field_title') }}
   {% endblock %}
 {% endblock paragraph %}


### PR DESCRIPTION
Add support for a title field within paragraphs.

## Description

When adding a paragraph an (optional) title is sometimes required. Add support to the master paragraph template to support that title.

## Motivation and Context

Centralised support for paragraph titles.

## How Has This Been Tested?

Tested for paragraphs that have and have not the field_title.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the style guide CHANGELOG accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
