### PR TITLE
DTGB-532: Fixed no longer loading typekit when no typekit_id is set.

### DIFF
--- a/templates/core/layout/html.html.twig
+++ b/templates/core/layout/html.html.twig
@@ -40,17 +40,19 @@
       <meta name="theme-color" content="{{ cs.hex }}" />
     {% endblock %}
 
-    <!-- Load Typekit -->
-    <script>
-      (function(d) {
-        var config = {
-            kitId: '{{ typekit_id }}',
-            scriptTimeout: 3000,
-            async: true
-          },
-          h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
-      })(document);
-    </script>
+    {% if typekit_id %}
+      <!-- Load Typekit -->
+      <script>
+        (function(d) {
+          var config = {
+                kitId: '{{ typekit_id }}',
+                scriptTimeout: 3000,
+                async: true
+              },
+              h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
+        })(document);
+      </script>
+    {% endif %}
 
     <css-placeholder token="{{ placeholder_token }}"></css-placeholder>
     <js-placeholder token="{{ placeholder_token }}"></js-placeholder>


### PR DESCRIPTION
When no Typekit id is set, all javascript scripts are blocked during 3000ms.

## Description

The code to load the Typekit javascript is always in the html head. Even if there is no Typekit id is set.

This forces the browser to try to load `https://use.typekit.net/.js`that can not be found.
Since the typekit script in the head has a timeout of 3000ms, all other scripts are blocked until this one has finished.

One of the side effects is that the text rendered with Google fonts is not shown during that period.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the style guide CHANGELOG accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
