### PR TITLE
DTGB-563: Fixed detecting the current node to insert the hero image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * DTGB-539: Refactored page template to use footer sections.
 * DTGB-539: Refactored timeline item wrappers to role listitem.
 * DTBG-539: Refactored image-gallery template to also use labelledby.
+* DTGB-563: Fixed detecting the current node to insert the hero image.
 
 ## gent_base-8.x-3.0
 

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -10,7 +10,6 @@ use Drupal\Core\Template\Attribute;
 use Drupal\Component\Utility\Html;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\paragraphs\Entity\Paragraph;
-use Drupal\node\NodeInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Link;
 use Drupal\file\Entity\File;
@@ -53,26 +52,34 @@ function gent_base_preprocess(&$variables, $hook) {
 }
 
 /**
- * Implements hook_preprocess().
+ * Implements hook_preprocess_page().
  */
 function gent_base_preprocess_page(&$variables) {
-  $routeMatch = \Drupal::routeMatch();
-  $entityTypeManager = \Drupal::entityTypeManager();
-  $entity = $routeMatch->getParameter('node');
+  gent_base_preprocess_page_hero_image($variables);
+}
 
-  if ($entity instanceof NodeInterface) {
-    $bundle = $entity->bundle();
-
-    $isViewMode = gent_base_is_view_mode('node.' . $bundle . '.hero_image');
-
-    if ($entity->access('view') && $isViewMode !== NULL) {
-      $render = $entityTypeManager->getViewBuilder('node');
-
-      $variables['hero_image'] = $render->view($entity, 'hero_image');
-    }
-  }
-  else {
+/**
+ * Helper to add the hero display of the current node to the page header.
+ */
+function gent_base_preprocess_page_hero_image(&$variables) {
+  $route = \Drupal::request()->get('_route');
+  if ($route !== 'entity.node.canonical') {
     $variables['attributes']['class'][] = 'overview-page';
+    return;
+  }
+
+  $entity = \Drupal::request()->get('node');
+  if (!$entity->access('view')) {
+    return;
+  }
+
+  $isViewMode = gent_base_is_view_mode(
+    'node.' . $entity->bundle() . '.hero_image'
+  );
+  if ($isViewMode) {
+    $variables['hero_image'] = \Drupal::entityTypeManager()
+      ->getViewBuilder('node')
+      ->view($entity, 'hero_image');
   }
 }
 


### PR DESCRIPTION
Fixed faulty current node detection on non-node pages within an Organic Groups group context.

## Description

### Problem

When a none-node page is displayed within a group context, the request will contain the group node as request parameter. The code in the gent_base theme detects that node and uses the hero_image of the group node. This is not the expected behaviour.

### Sollution

Check first if the current route is a node detail page (entity.node.canonical).

## Motivation and Context

Fix issue DTGB-563.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the gent_base CHANGELOG accordingly.
