### PR TITLE
DTGB-573: Update link styling to make sure icons don't wrap to the next line

### DIFF
--- a/styleguide/components/21-atoms/link/_link.scss
+++ b/styleguide/components/21-atoms/link/_link.scss
@@ -97,7 +97,9 @@ a {
   &.standalone-link {
     @include icon(arrow-right, after);
 
+    display: inline-block;
     margin-left: 0;
+    padding-right: calc(#{$link-padding} + 1.5em + .2rem);
     padding-left: 0;
     text-decoration: none;
 
@@ -106,6 +108,11 @@ a {
       @include theme('color', 'color-primary--darken-2', 'link-hover-color');
 
       background-color: transparent;
+    }
+
+    &::after {
+      display: inline-block;
+      margin-right: calc(-1em - .2rem - #{$link-padding});
     }
   }
 
@@ -118,10 +125,12 @@ a {
   &[download]:not(.button),
   &[href^="http://"]:not(.button),
   &[href^="https://"]:not(.button) {
-    display: inline;
+    display: inline-block;
+    padding-right: calc(#{$link-padding} + 1.5em + .2rem);
 
     &::after {
       display: inline-block;
+      margin-right: calc(-1em - .2rem - #{$link-padding});
       text-decoration: none;
       overflow: hidden; // Hides text decoration underline.
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested locally with dummy copy (see screenshot)

## Screenshots (if appropriate):
<img src="https://user-images.githubusercontent.com/4415097/46743614-bc91a100-cca9-11e8-857b-56ddc5607e99.png" width="200" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the style guide CHANGELOG accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
- [ ] I have ran gulp axe on the compiled files and found no errors.
