### PR TITLE
DTGB-573: Fixed line-height issue for links in other components

### DIFF
--- a/styleguide/components/21-atoms/link/_link.scss
+++ b/styleguide/components/21-atoms/link/_link.scss
@@ -102,8 +102,7 @@ a {
   &.standalone-link {
     @include icon(arrow-right, after);
 
-    display: inline-block;
-    margin-left: 0;
+    display: inline;
     padding-right: calc(#{$link-padding} + 1.5em + .2rem);
     padding-left: 0;
     text-decoration: none;
@@ -130,7 +129,7 @@ a {
   &[download]:not(.button),
   &[href^="http://"]:not(.button),
   &[href^="https://"]:not(.button) {
-    display: inline-block;
+    display: inline;
     padding-right: calc(#{$link-padding} + 1.5em + .2rem);
 
     &::after {

--- a/styleguide/components/31-molecules/teasers/_teaser.scss
+++ b/styleguide/components/31-molecules/teasers/_teaser.scss
@@ -34,11 +34,6 @@
       z-index: 2;
     }
 
-    a.read-more {
-      margin-left: 0;
-      line-height: 1em;
-    }
-
     span.teaser-label {
       display: flex;
       position: absolute;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Cross-browser solution for preventing the icons to wrap to the next line (without any text).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since the previous solution for icon wrapping caused issues in other components (for example the article teaser) when the line-height was adapted; I updated the styling again..

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in: 
* Chrome on OS X 
* Firefox on OS X
* Safari on OS X
* IE11 on Windows 10
* Edge on Windows 10
* IE11 on Windows 7

## Screenshots (if appropriate):
<img src="https://user-images.githubusercontent.com/4415097/47065684-28ad6100-d1e4-11e8-84ab-2fefc795d921.png" width="250" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the style guide CHANGELOG accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
- [ ] I have ran gulp axe on the compiled files and found no errors.
