### PR TITLE
Don't execute exposed methods in modal functions

### DIFF
--- a/styleguide/components/31-molecules/modal/modal.functions.js
+++ b/styleguide/components/31-molecules/modal/modal.functions.js
@@ -243,6 +243,6 @@
 
     init();
 
-    return {close: handleClose(), open: open()};
+    return {close: handleClose, open: open};
   };
 });

--- a/templates/core/layout/region--filters.html.twig
+++ b/templates/core/layout/region--filters.html.twig
@@ -14,6 +14,7 @@
 #}
 {%
   set classes = [
+  'has-custom-binding',
   'filter-section',
   'sidebar',
   'modal',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

A `history.back()` prevented the user from viewing any page with a modal.

Cause: Modals were openend AND closed upon page load because the exposed methods were executed immediately when the component was loaded. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the style guide CHANGELOG accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
- [ ] I have ran gulp axe on the compiled files and found no errors.
