### PR TITLE
DTGB-621: Modal enhancements

### DIFF
--- a/styleguide/CHANGELOG.md
+++ b/styleguide/CHANGELOG.md
@@ -6,12 +6,17 @@ NOTE: Refer to upcoming changes in our README.md under "Roadmap"
 
 ## [Unreleased]
 
-* DTGB-665: Refactored pages to only show layouts. This shouldn't affect any
-  custom projects.
+### Added
+
+* DTGB-621: Modal component in molecules tree (i.e. this component isn't hidden anymore).
   
 ### Updated 
 
 * DTGB-676: Exposed modal open and close functions.
+* DTGB-665: Refactored pages to only show layouts. This shouldn't affect any
+  custom projects.
+* DTGB-621: Cross-browser behavior of the modal component.
+* DTGB-621: Focus management of the modal component.
 
 ## [3.0.0-alpha11]
 

--- a/styleguide/components/31-molecules/checkbox-with-filter/checkbox-with-filter.twig
+++ b/styleguide/components/31-molecules/checkbox-with-filter/checkbox-with-filter.twig
@@ -1,10 +1,11 @@
 {% extends "_form-item--fieldset.template.twig" %}
+
+{% set modalTitle = label %}
+{% if label_optional %}
+  {% set modalTitle = modalTitle ~ '<span class="label-optional">(' ~ label_optional ~ ')</span>' %}
+{% endif %}
+
 {% set modalContent %}
-  <h3>{{ label }}
-    {% if label_optional %}
-      <span class="label-optional">({{ label_optional }})</span>
-    {% endif %}
-  </h3>
   <div class="checkbox-filter__selected"></div>
   <div class="form-item">
     <label for="checkboxes__filter_id_{{ modifier }}">Filter the list
@@ -53,6 +54,7 @@
 {% block options %}
   {% include "@modal" with {
     id: 'modal' ~ modifier,
+    title: modalTitle,
     classes: 'checkbox-filter__modal',
     cancelClasses: 'checkbox-filter__close',
     modifier: 'fixed-height',

--- a/styleguide/components/31-molecules/modal/_modal.scss
+++ b/styleguide/components/31-molecules/modal/_modal.scss
@@ -5,9 +5,8 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  box-shadow: $box-shadow-primary color('dark-gray', -4, true);
   visibility: hidden;
-  z-index: 997;
+  z-index: 999;
   overflow-y: auto;
 
   // states
@@ -15,7 +14,7 @@
     visibility: visible;
 
     @include tablet {
-      .modal-overlay {
+      + .modal-overlay {
         display: block;
       }
     }
@@ -31,7 +30,7 @@
     width: 100%;
     min-height: 100%;
     background-color: color('white');
-    z-index: 999;
+    box-shadow: $box-shadow-primary color('dark-gray', -4, true);
 
     @include tablet {
       right: 0;
@@ -49,7 +48,8 @@
       height: 100%;
 
       @include tablet {
-        height: 80vh;
+        height: auto;
+        max-height: 80vh;
       }
 
       > .modal-content {
@@ -108,7 +108,7 @@
   /// Actions
   ///
   &-actions {
-    @include theme('border-color', 'color-primary--lighten-4', 'checkbox-with-filter-action-border-bottom');
+    @include theme('border-color', 'color-primary--lighten-4', 'modal-action-border-bottom');
 
     display: flex;
     flex-shrink: 0;
@@ -126,7 +126,7 @@
   ///
   /// Overlay
   ///
-  &-overlay {
+  + .modal-overlay {
     display: none;
     position: fixed;
     top: 0;
@@ -139,7 +139,7 @@
     &,
     &:hover,
     &:focus {
-      @include theme('background-color', 'color-primary--darken-3', 'checkbox-with-filter-overlay-background-color');
+      @include theme('background-color', 'color-primary--darken-3', 'modal-overlay-background-color');
     }
   }
 }

--- a/styleguide/components/31-molecules/modal/_modal.scss
+++ b/styleguide/components/31-molecules/modal/_modal.scss
@@ -6,7 +6,7 @@
   width: 100vw;
   height: 100vh;
   visibility: hidden;
-  z-index: 999;
+  z-index: 997;
   overflow-y: auto;
 
   // states
@@ -14,7 +14,7 @@
     visibility: visible;
 
     @include tablet {
-      + .modal-overlay {
+      .modal-overlay {
         display: block;
       }
     }
@@ -31,6 +31,7 @@
     min-height: 100%;
     background-color: color('white');
     box-shadow: $box-shadow-primary color('dark-gray', -4, true);
+    z-index: 999;
 
     @include tablet {
       right: 0;
@@ -126,7 +127,7 @@
   ///
   /// Overlay
   ///
-  + .modal-overlay {
+  .modal-overlay {
     display: none;
     position: fixed;
     top: 0;

--- a/styleguide/components/31-molecules/modal/_modal.scss
+++ b/styleguide/components/31-molecules/modal/_modal.scss
@@ -40,10 +40,10 @@
     flex-direction: column;
     width: 100%;
     min-height: 100%;
+    margin: 0 auto;
     background-clip: content-box;
     background-color: color('white');
     z-index: 999;
-    margin: 0 auto;
     filter: drop-shadow(0 2px 8px #{color('dark-gray', -4, true)});
 
     @include tablet {

--- a/styleguide/components/31-molecules/modal/_modal.scss
+++ b/styleguide/components/31-molecules/modal/_modal.scss
@@ -23,10 +23,10 @@
   // modifiers
   &--fixed-height {
     > .modal-inner {
-      max-height: 100%;
+      max-height: 80vh;
 
       @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-        height: 100%; // IE fix
+        height: 80vh; // IE fix
       }
 
       > .modal-content {
@@ -56,7 +56,8 @@
       max-width: $bp-max-content * .8;
       height: auto;
       min-height: 0;
-      padding: 10vh 10vw;
+      margin: 10vh auto 0;
+      padding-bottom: $gutter-width;
     }
   }
 

--- a/styleguide/components/31-molecules/modal/_modal.scss
+++ b/styleguide/components/31-molecules/modal/_modal.scss
@@ -23,7 +23,7 @@
   // modifiers
   &--fixed-height {
     > .modal-inner {
-      height: 100%;
+      max-height: 100%;
 
       > .modal-content {
         overflow-y: auto;

--- a/styleguide/components/31-molecules/modal/_modal.scss
+++ b/styleguide/components/31-molecules/modal/_modal.scss
@@ -2,9 +2,9 @@
   display: flex;
   position: fixed;
   top: 0;
+  right: 0;
+  bottom: 0;
   left: 0;
-  width: 100vw;
-  height: 100vh;
   visibility: hidden;
   z-index: 997;
   overflow-y: auto;
@@ -20,6 +20,17 @@
     }
   }
 
+  // modifiers
+  &--fixed-height {
+    > .modal-inner {
+      height: 100%;
+
+      > .modal-content {
+        overflow-y: auto;
+      }
+    }
+  }
+
   // children
   &-inner {
     display: flex;
@@ -29,33 +40,18 @@
     flex-direction: column;
     width: 100%;
     min-height: 100%;
+    background-clip: content-box;
     background-color: color('white');
-    box-shadow: $box-shadow-primary color('dark-gray', -4, true);
     z-index: 999;
+    margin: 0 auto;
+    filter: drop-shadow(0 2px 8px #{color('dark-gray', -4, true)});
 
     @include tablet {
       right: 0;
-      width: 80vw;
       max-width: $bp-max-content * .8;
       height: auto;
       min-height: 0;
-      margin: 10vh auto $gutter-width;
-    }
-  }
-
-  // modifiers
-  &--fixed-height {
-    > .modal-inner {
-      height: 100%;
-
-      @include tablet {
-        height: auto;
-        max-height: 80vh;
-      }
-
-      > .modal-content {
-        overflow-y: auto;
-      }
+      padding: 10vh 10vw;
     }
   }
 

--- a/styleguide/components/31-molecules/modal/_modal.scss
+++ b/styleguide/components/31-molecules/modal/_modal.scss
@@ -25,7 +25,12 @@
     > .modal-inner {
       max-height: 100%;
 
+      @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+        height: 100%; // IE fix
+      }
+
       > .modal-content {
+        flex-grow: 1;
         overflow-y: auto;
       }
     }

--- a/styleguide/components/31-molecules/modal/modal.config.js
+++ b/styleguide/components/31-molecules/modal/modal.config.js
@@ -37,12 +37,12 @@ module.exports = {
   variants: [
     {
       name: 'default',
-      preview: '@preview-modal'
+      preview: '@preview'
     },
     {
       name: 'fixed-height',
       label: 'Fixed Height',
-      preview: '@preview-modal',
+      preview: '@preview',
       context: {
         id: 'modal-fixed',
         modifier: 'fixed-height',

--- a/styleguide/components/31-molecules/modal/modal.config.js
+++ b/styleguide/components/31-molecules/modal/modal.config.js
@@ -1,23 +1,52 @@
 'use strict';
 
 module.exports = {
-  title: 'Modal',
-  name: 'modal',
-  status: 'alpha',
+  status: 'beta',
   preview: '@preview-description-list',
-  hidden: true,
+  collated: 'true',
+  collator: function (markup, item) {
+    return `<!-- Start: @${item.name} -->
+            <dt>${item.name}</dt>
+            <dd>
+              ${markup}
+              <button class="button button-primary" aria-controls="${item.context.id}">Open modal</button>
+            </dd>
+            <!-- End: @${item.name} -->`;
+  },
+  context: {
+    id: 'modal',
+    title: 'An example modal',
+    content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum imperdiet vestibulum ex, id tincidunt nulla porttitor nec. Cras aliquam interdum felis, nec efficitur quam varius sit amet. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut nec gravida tellus, quis pulvinar enim. Proin ut lectus dui. Pellentesque maximus orci quis aliquet bibendum. Fusce vestibulum velit a tellus fermentum, in laoreet est pharetra.<br/>' +
+      '<br/>' +
+      'Fusce sed lacus turpis. Praesent ultrices viverra neque vel fermentum. Donec pulvinar ligula et iaculis euismod. Donec rhoncus cursus lacus, et pharetra ligula tristique non. Morbi nec ligula ornare, semper orci sit amet, varius massa. Fusce magna quam, condimentum et rhoncus et, porttitor at turpis. Donec id nunc dapibus, consequat massa a, cursus odio. Aliquam in dignissim sem. Suspendisse potenti. Etiam at metus vitae urna viverra luctus. Donec convallis interdum convallis. Donec volutpat eget velit in varius. Nam porta varius urna at eleifend. In elit ex, vestibulum non ex a, suscipit semper dui. Integer dictum lacus augue, vitae rhoncus lorem tempor eget.<br/>' +
+      '<br/>' +
+      'Integer nec suscipit dui. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Curabitur non finibus felis. Nunc faucibus sapien at fermentum semper. Donec congue egestas felis, eget ultrices augue commodo in. Aliquam vitae elit diam. Nulla auctor velit sed nisl lacinia, sit amet tincidunt lectus consectetur. Aliquam sit amet hendrerit lacus. Curabitur lacus enim, tempus eget massa id, varius elementum quam. Praesent pulvinar facilisis lacinia. Quisque congue imperdiet nunc vitae dictum. Nulla a nisi neque. Mauris sed mollis orci. Pellentesque sagittis tempus diam. Phasellus malesuada diam sed lectus fringilla pellentesque. Nullam sit amet bibendum magna, et hendrerit tellus.<br/>' +
+      '<br/>' +
+      'In ultrices, libero in pretium elementum, arcu est eleifend leo, et luctus ante orci nec mi. Sed ac facilisis sapien, sit amet dignissim erat. Nulla malesuada quam vitae leo iaculis fermentum. Aliquam condimentum odio at metus malesuada, et gravida nisi ornare. Sed lobortis eros eu dolor pulvinar porta. Sed luctus auctor pulvinar. Etiam laoreet interdum rhoncus. Aliquam in quam posuere ligula faucibus auctor.<br/>' +
+      '<br/>' +
+      'Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer condimentum mauris non urna scelerisque bibendum. Nulla facilisi. Curabitur sed mi fermentum, maximus lorem eu, laoreet purus. Vivamus ultricies consequat odio, a tristique erat varius ac. Morbi feugiat, nisl eu vehicula elementum, ipsum orci laoreet eros, id hendrerit enim sem in dolor. Maecenas augue ligula, vehicula a risus blandit, volutpat euismod felis. Aliquam maximus, tortor sed tincidunt volutpat, lorem ex dictum sem, eu scelerisque augue mi vitae orci. Nam imperdiet magna porttitor nunc finibus accumsan. Nullam maximus, nulla sit amet lobortis ullamcorper, erat nulla ornare lacus, non ullamcorper felis mi a nibh. Integer eget pulvinar quam.' +
+      '<br/>' +
+      'Fusce sed lacus turpis. Praesent ultrices viverra neque vel fermentum. Donec pulvinar ligula et iaculis euismod. Donec rhoncus cursus lacus, et pharetra ligula tristique non. Morbi nec ligula ornare, semper orci sit amet, varius massa. Fusce magna quam, condimentum et rhoncus et, porttitor at turpis. Donec id nunc dapibus, consequat massa a, cursus odio. Aliquam in dignissim sem. Suspendisse potenti. Etiam at metus vitae urna viverra luctus. Donec convallis interdum convallis. Donec volutpat eget velit in varius. Nam porta varius urna at eleifend. In elit ex, vestibulum non ex a, suscipit semper dui. Integer dictum lacus augue, vitae rhoncus lorem tempor eget.<br/>' +
+      '<br/>' +
+      'Integer nec suscipit dui. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Curabitur non finibus felis. Nunc faucibus sapien at fermentum semper. Donec congue egestas felis, eget ultrices augue commodo in. Aliquam vitae elit diam. Nulla auctor velit sed nisl lacinia, sit amet tincidunt lectus consectetur. Aliquam sit amet hendrerit lacus. Curabitur lacus enim, tempus eget massa id, varius elementum quam. Praesent pulvinar facilisis lacinia. Quisque congue imperdiet nunc vitae dictum. Nulla a nisi neque. Mauris sed mollis orci. Pellentesque sagittis tempus diam. Phasellus malesuada diam sed lectus fringilla pellentesque. Nullam sit amet bibendum magna, et hendrerit tellus.<br/>' +
+      '<br/>' +
+      'In ultrices, libero in pretium elementum, arcu est eleifend leo, et luctus ante orci nec mi. Sed ac facilisis sapien, sit amet dignissim erat. Nulla malesuada quam vitae leo iaculis fermentum. Aliquam condimentum odio at metus malesuada, et gravida nisi ornare. Sed lobortis eros eu dolor pulvinar porta. Sed luctus auctor pulvinar. Etiam laoreet interdum rhoncus. Aliquam in quam posuere ligula faucibus auctor.<br/>' +
+      '<br/>' +
+      'Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer condimentum mauris non urna scelerisque bibendum. Nulla facilisi. Curabitur sed mi fermentum, maximus lorem eu, laoreet purus. Vivamus ultricies consequat odio, a tristique erat varius ac. Morbi feugiat, nisl eu vehicula elementum, ipsum orci laoreet eros, id hendrerit enim sem in dolor. Maecenas augue ligula, vehicula a risus blandit, volutpat euismod felis. Aliquam maximus, tortor sed tincidunt volutpat, lorem ex dictum sem, eu scelerisque augue mi vitae orci. Nam imperdiet magna porttitor nunc finibus accumsan. Nullam maximus, nulla sit amet lobortis ullamcorper, erat nulla ornare lacus, non ullamcorper felis mi a nibh. Integer eget pulvinar quam.'
+  },
   variants: [
     {
       name: 'default',
-      preview: '@preview',
-      hidden: true
+      preview: '@preview-modal'
     },
     {
       name: 'fixed-height',
       label: 'Fixed Height',
-      preview: '@preview',
+      preview: '@preview-modal',
       context: {
-        modifier: 'fixed-height'
+        id: 'modal-fixed',
+        modifier: 'fixed-height',
+        actions: '<button type="button" class="button button-primary modal-close" data-target="modal-fixed">Understood!</button>'
       }
     }
   ]

--- a/styleguide/components/31-molecules/modal/modal.functions.js
+++ b/styleguide/components/31-molecules/modal/modal.functions.js
@@ -149,7 +149,8 @@
       if (trigger) {
         trigger.setAttribute('aria-expanded', 'true');
       }
-      modal.focus();
+
+      tabTrap.home();
     };
 
     /**

--- a/styleguide/components/31-molecules/modal/modal.functions.js
+++ b/styleguide/components/31-molecules/modal/modal.functions.js
@@ -56,7 +56,7 @@
     }
 
     let triggers = [];
-    let trigger;
+    let activeTrigger;
     let hash;
 
     /**
@@ -78,10 +78,14 @@
       modal.setAttribute('tabindex', '-1');
       modal.setAttribute('aria-hidden', 'true');
 
+      let _open = e => {
+        activeTrigger = e.currentTarget;
+        open();
+      };
+
       for (let i = triggers.length; i--;) {
-        trigger = triggers[i];
-        trigger.setAttribute('aria-expanded', 'false');
-        trigger.addEventListener('click', ()=>{ open(); });
+        triggers[i].setAttribute('aria-expanded', 'false');
+        triggers[i].addEventListener('click', _open);
       }
 
       /**
@@ -146,8 +150,8 @@
       modal.setAttribute('aria-hidden', 'false');
       scrollLockParent();
       document.addEventListener('keydown', handleKeyboardInput);
-      if (trigger) {
-        trigger.setAttribute('aria-expanded', 'true');
+      if (activeTrigger) {
+        activeTrigger.setAttribute('aria-expanded', 'true');
       }
 
       tabTrap.home();
@@ -161,9 +165,9 @@
       modal.setAttribute('aria-hidden', 'true');
       scrollLockParent(true);
       document.removeEventListener('keydown', handleKeyboardInput);
-      if (trigger) {
-        trigger.setAttribute('aria-expanded', 'false');
-        trigger.focus();
+      if (activeTrigger) {
+        activeTrigger.setAttribute('aria-expanded', 'false');
+        activeTrigger.focus();
       }
     };
 

--- a/styleguide/components/31-molecules/modal/modal.functions.js
+++ b/styleguide/components/31-molecules/modal/modal.functions.js
@@ -69,7 +69,7 @@
      * Initialise the component.
      */
     const init = () => {
-      triggers = document.querySelectorAll(`[aria-controls="${modal.id}"]`);
+      triggers = document.querySelectorAll(`[aria-controls="${modal.id}"], [href="#${modal.id}"]`);
 
       if (!options.changeHash && triggers.length === 0) {
         return;
@@ -80,7 +80,10 @@
 
       let _open = e => {
         activeTrigger = e.currentTarget;
-        open();
+
+        if (activeTrigger.hasAttribute('aria-controls')) {
+          open();
+        }
       };
 
       for (let i = triggers.length; i--;) {

--- a/styleguide/components/31-molecules/modal/modal.twig
+++ b/styleguide/components/31-molecules/modal/modal.twig
@@ -22,5 +22,5 @@
     {% endif %}
   </div>
 
+  <div class="modal-overlay modal-close{{ cancelClasses ? ' ' ~ cancelClasses }}" data-target="{{ id }}" tabindex="-1"></div>
 </div>
-<div class="modal-overlay modal-close{{ cancelClasses ? ' ' ~ cancelClasses }}" data-target="{{ id }}" tabindex="-1"></div>

--- a/styleguide/components/31-molecules/modal/modal.twig
+++ b/styleguide/components/31-molecules/modal/modal.twig
@@ -3,7 +3,8 @@
     class="modal{{ modifier ? ' modal--' ~ modifier }}{{ classes ? ' ' ~ classes }}"
     role="dialog"
     aria-modal="true"
-    aria-labelledby="{{ id }}-title">
+    aria-labelledby="{{ id }}-title"
+    tabindex="-1">
 
   <div class="modal-inner">
     <div class="modal-header">

--- a/styleguide/components/31-molecules/modal/modal.twig
+++ b/styleguide/components/31-molecules/modal/modal.twig
@@ -13,7 +13,7 @@
       </button>
     </div>
     <div class="modal-content">
-      <h2 id="{{ id }}-title">{{ title }}</h2>
+      <{{ title_heading_level|default('h3') }} id="{{ id }}-title">{{ title }}</{{ title_heading_level|default('h3') }}>
       {{ content }}
     </div>
     {% if actions %}

--- a/styleguide/components/31-molecules/modal/modal.twig
+++ b/styleguide/components/31-molecules/modal/modal.twig
@@ -1,4 +1,10 @@
-<section id="{{ id }}" class="modal{{ modifier ? ' modal--' ~ modifier }}{{ classes ? ' ' ~ classes }}" tabindex="-1">
+<div
+    id="{{ id }}"
+    class="modal{{ modifier ? ' modal--' ~ modifier }}{{ classes ? ' ' ~ classes }}"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="{{ id }}-title">
+
   <div class="modal-inner">
     <div class="modal-header">
       <button type="button" class="button close icon-cross modal-close{{ cancelClasses ? ' ' ~ cancelClasses }}" data-target="{{ id }}">
@@ -6,6 +12,7 @@
       </button>
     </div>
     <div class="modal-content">
+      <h2 id="{{ id }}-title">{{ title }}</h2>
       {{ content }}
     </div>
     {% if actions %}
@@ -14,5 +21,6 @@
       </div>
     {% endif %}
   </div>
-  <div class="modal-overlay modal-close{{ cancelClasses ? ' ' ~ cancelClasses }}" data-target="{{ id }}"></div>
-</section>
+
+</div>
+<div class="modal-overlay modal-close{{ cancelClasses ? ' ' ~ cancelClasses }}" data-target="{{ id }}" tabindex="-1"></div>

--- a/styleguide/components/41-organisms/filter/_filter.scss
+++ b/styleguide/components/41-organisms/filter/_filter.scss
@@ -33,6 +33,7 @@
         margin: 0;
         transform: none;
         z-index: auto;
+        filter: none;
       }
 
       > .modal-header {

--- a/styleguide/components/41-organisms/filter/filter.twig
+++ b/styleguide/components/41-organisms/filter/filter.twig
@@ -1,6 +1,5 @@
 <div class="sidebar-layout filter">
   {% set modalContent %}
-    <h2>Filter the results</h2>
 
     <form action="#result">
       <div class="form-item">
@@ -55,6 +54,8 @@
   {% endset %}
   {% include "@modal" with {
     id: 'filter',
+    title: 'Filter the results',
+    title_heading_level: 'h2',
     classes: 'sidebar filter-section has-custom-binding',
     content: modalContent
   } %}

--- a/styleguide/components/41-organisms/programme/programme.twig
+++ b/styleguide/components/41-organisms/programme/programme.twig
@@ -10,8 +10,6 @@
             {% for itemKey, item in slot.items %}
               {% set key = slotKey ~ itemKey %}
               {% set modalContent %}
-
-              <h3>{{ item.title }}</h3>
               <h4>{{ slot.title }}</h4>
 
               {% if item.subtitle %}
@@ -46,6 +44,7 @@
               <!-- Modal -->
               {% include "@modal" with {
                 id: key,
+                title: item.title,
                 content: modalContent,
                 classes: 'programme-detail'
               } %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
### 1. Revealed modal component in tree
Where the modal component was initially hidden in the tree; it now has it's own component housed under the molecules-section. 

There are 2 variants, named: 
- **default**: A simple modal with a title and some text-content.
- **fixed height**: A modal that never exceeds the height of the viewport; with a fixed header on top, scrollable content and fixed action buttons at the bottom. 

### 2. Improved focus management
When a modal is closed, the focus is now moved back to the element that triggered the modal to open in the first place. When a modal is opened on page load, focus will be moved to the body element. 

### 3. Added attributes for accessibility
Following attributes were added to the modal element: 
- `aria-modal=true`
- `role=dialog`
- `aria-labelledby`

### 4. Cross-browser fixes
Solved: 
- Modal actions not clickable on safari on mobile devices.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
### Windows
- IE11
- IE Edge

### OSX
- Chrome
- Safari

### iOS (iPad & iPhone 5)
- Chrome
- Safari

## Screenshots (if appropriate):
![ezgif-4-45e454eede16](https://user-images.githubusercontent.com/4415097/51741226-9d6f2180-2096-11e9-9f97-9b74dbb5e4a2.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the style guide CHANGELOG 
accordingly.
- [x] I have ran gulp axe on the compiled files and found no errors.
