### PR TITLE
Fixed conflicting keyframes name 'bounce'

### DIFF
--- a/styleguide/components/21-atoms/link/_link.scss
+++ b/styleguide/components/21-atoms/link/_link.scss
@@ -117,7 +117,7 @@ a {
 
   &.standalone-link:not([href^="mailto:"]):not([href^="tel:"]):not([download]):not([href^="http://"]):not([href^="https://"]):not(.back),
   &.button:not([href^="mailto:"]):not([href^="tel:"]):not([download]):not([href^="http://"]):not([href^="https://"]):not([class*="icon-"]) {
-    @extend %a-bounce-animation;
+    @extend %a-arrow-animation;
   }
 
   &[href^="mailto:"]:not(.button),
@@ -168,7 +168,7 @@ a {
   }
 
   &.back:not(.no-icon) {
-    @extend %a-bounce-animation--left;
+    @extend %a-arrow-animation--left;
     @include icon(fancyback, after);
 
     flex-direction: row-reverse;
@@ -182,7 +182,7 @@ a {
   }
 }
 
-%a-bounce-animation {
+%a-arrow-animation {
   &::after,
   &::before {
     padding-right: .2rem;
@@ -192,7 +192,7 @@ a {
   &:hover {
     &::after,
     &::before {
-      animation: bounce 1s 2;
+      animation: arrow 1s 2;
 
       // Animation causes pointer flickering in IE.
       @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) { // sass-lint:disable-line no-vendor-prefixes
@@ -201,7 +201,7 @@ a {
     }
   }
 
-  @keyframes bounce {
+  @keyframes arrow {
     0% {
       padding-right: .2rem;
       padding-left: 0;
@@ -219,12 +219,12 @@ a {
   }
 }
 
-%a-bounce-animation--left {
+%a-arrow-animation--left {
   &:focus,
   &:hover {
     &::after,
     &::before {
-      animation: bounce-left 1s 2;
+      animation: arrow-left 1s 2;
 
       // Animation causes pointer flickering in IE.
       @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) { // sass-lint:disable-line no-vendor-prefixes
@@ -233,7 +233,7 @@ a {
     }
   }
 
-  @keyframes bounce-left {
+  @keyframes arrow-left {
     0% {
       padding-right: .2rem;
       padding-left: .4rem;
@@ -273,7 +273,7 @@ a {
       /// Stand alone links.
       ///
       &.standalone-link:not(.no-icon) {
-        @extend %a-bounce-animation;
+        @extend %a-arrow-animation;
         @include icon(arrow-right, after);
       }
     }
@@ -283,7 +283,7 @@ a {
     &[href^="http://"]:not(.no-icon),
     &[href^="https://"]:not(.no-icon) {
       &[href*="stad.gent"]:not(.no-icon) {
-        @extend %a-bounce-animation;
+        @extend %a-arrow-animation;
         @include icon(arrow-right);
 
         &::after {

--- a/styleguide/components/31-molecules/pagination/_pagination.scss
+++ b/styleguide/components/31-molecules/pagination/_pagination.scss
@@ -98,7 +98,7 @@
 
     .next {
       a {
-        @extend %a-bounce-animation;
+        @extend %a-arrow-animation;
         @include icon(arrow-right, after);
 
         padding-right: 0;
@@ -112,7 +112,7 @@
 
     .previous {
       a {
-        @extend %a-bounce-animation--left;
+        @extend %a-arrow-animation--left;
         @include icon(arrow-left, after);
 
         flex-direction: row-reverse;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Because of a conflict in the keyframes naming of `bounce`, the link arrow animation was broken. 
https://github.com/BartDelrue/baguetteBox.js/blob/7a4baff3990bfddd15cbe232ad077bcfe5491f1d/src/baguetteBox.scss#L190-L196

This occurred only on pages where links were displayed AND the baguetteBox css files were loaded.

### Before
![ezgif-4-ef09e0ef8fa1](https://user-images.githubusercontent.com/4415097/52195447-4ddbe300-2858-11e9-8f03-e09d4c0a452d.gif)

### After
![ezgif-4-49c4126f7ea2](https://user-images.githubusercontent.com/4415097/52195452-4f0d1000-2858-11e9-8f64-121e7757f750.gif)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the style guide CHANGELOG accordingly.
- [x] I have ran gulp axe on the compiled files and found no errors.
