### PR TITLE
DTGB-491: Don't render empty features in popup

### DIFF
--- a/gent_base.libraries.yml
+++ b/gent_base.libraries.yml
@@ -84,7 +84,10 @@ opening_hours:
 maps:
   version: 1.x
   js:
-    build/js/dg_maps.functions-min.js: { minified: true }
+    build/js/dg_maps.datalayerswitcher-min.js: { minified: true }
+    build/js/dg_maps.regions-min.js: { minified: true }
+    build/js/dg_maps.baselayerswitcher-min.js: { minified: true }
+    build/js/dg_maps.popup-min.js: { minified: true }
     build/js/dg_maps.styles-min.js: { minified: true }
     build/js/dg_maps.bindings-min.js: { minified: true }
   dependencies:

--- a/source/js/dg_maps.baselayerswitcher.js
+++ b/source/js/dg_maps.baselayerswitcher.js
@@ -1,4 +1,4 @@
-/* global ol, drupalSettings */
+/* global ol */
 /**
  * @file
  * DG Maps functionality extensions.
@@ -45,7 +45,7 @@
       if (!this_.panel.contains(e.toElement || e.relatedTarget)) {
         this_.hidePanel();
       }
-    };;
+    };
 
     ol.control.Control.call(this, {
       element: element,

--- a/source/js/dg_maps.baselayerswitcher.js
+++ b/source/js/dg_maps.baselayerswitcher.js
@@ -1,0 +1,90 @@
+/* global ol, drupalSettings */
+/**
+ * @file
+ * DG Maps functionality extensions.
+ */
+(function ($, Drupal) {
+  'use strict';
+
+  var originalPrototype = Drupal.dgMaps.ol.control.BaseLayerSwitcher.prototype;
+
+
+  /**
+   * Base Layer Switcher control.
+   *
+   * @constructor
+   * @extends {ol.control.Control}
+   * @param {Object=} opt_options Control options.
+   */
+  Drupal.dgMaps.ol.control.BaseLayerSwitcher = function (opt_options) {
+
+    var options = opt_options || {};
+
+    this.hiddenClassName = 'ol-base-layer-switcher ol-unselectable ol-control';
+    this.shownClassName = 'shown';
+
+    var element = document.createElement('div');
+    element.className = this.hiddenClassName;
+
+    this.button = document.createElement('button');
+    this.button.setAttribute('title', Drupal.t('Legend'));
+    element.appendChild(this.button);
+
+    this.panel = document.createElement('div');
+    this.panel.className = 'selection';
+    element.appendChild(this.panel);
+
+    var this_ = this;
+
+    this.button.onmouseover = function () {
+      this_.showPanel();
+    };
+
+    this_.panel.onmouseout = function (e) {
+      e = e || window.event;
+      if (!this_.panel.contains(e.toElement || e.relatedTarget)) {
+        this_.hidePanel();
+      }
+    };;
+
+    ol.control.Control.call(this, {
+      element: element,
+      target: options.target
+    });
+  };
+
+  /**
+   * Render a base layer as list item.
+   * @param {ol.layer.Layer} layer Layer to be rendered.
+   * @return {Element} The layer as list item.
+   * @private
+   */
+  originalPrototype.renderLayer_ = function (layer) {
+    var li = document.createElement('li');
+    li.className = 'layer layer-' + layer.get('id');
+
+    var lyrId = Drupal.dgMaps.uuid();
+
+    var input = document.createElement('input');
+    input.type = 'radio';
+    input.name = 'base';
+    input.id = lyrId;
+    input.checked = layer.get('visible');
+    input.onchange = function (e) {
+      this.setVisible_(layer, e.target.checked);
+      this.hidePanel();
+    }.bind(this);
+    li.appendChild(input);
+
+    var label = document.createElement('label');
+    label.htmlFor = lyrId;
+    label.innerHTML = layer.get('title');
+    label.title = layer.get('title');
+    li.appendChild(label);
+
+    return li;
+  };
+
+  Drupal.dgMaps.ol.control.BaseLayerSwitcher.prototype = originalPrototype;
+})(jQuery, Drupal);
+

--- a/source/js/dg_maps.datalayerswitcher.js
+++ b/source/js/dg_maps.datalayerswitcher.js
@@ -1,4 +1,4 @@
-/* global ol, drupalSettings, Mustache */
+/* global ol, drupalSettings */
 /**
  * @file
  * DG Maps functionality extensions.
@@ -152,67 +152,5 @@
   };
 
   Drupal.dgMaps.ol.control.DataLayerSwitcher.prototype = originalPrototype;
-
-  var _initRegion = Drupal.dgMaps.initRegions;
-
-  /**
-   * Performs region initialisation.
-   * @param {Object} map - The map.
-   * @param {jQuery} mapElement - The map container element.
-   */
-  Drupal.dgMaps.initRegions = function (map, mapElement) {
-    _initRegion(map, mapElement);
-
-    // Close the legend by default
-    var mapContainer = mapElement.parents('.map-container');
-    var legendToggle = mapContainer.find('button[data-toggle-region="left"]');
-
-    legendToggle
-      .on('click', function () {
-        var region = $('.' + this.getAttribute('aria-controls'));
-        legendToggle.attr('aria-expanded', region.is(':visible'));
-      })
-      .first().click();
-  };
-
-  /**
-   * Adds a feature as popup item to the internal popup items storage.
-   * @param {ol.Feature} feature The feature to add.
-   * @param {string} layerId The layer id the feature is from.
-   * @api
-   */
-  Drupal.dgMaps.ol.interaction.Popup.prototype.addFeature = function (feature, layerId) {
-    var features = feature.get('features');
-    if (typeof features === 'undefined') {
-      features = [feature];
-    }
-
-    var template;
-    var title;
-    var description;
-
-    for (var i = 0; i < features.length; i++) {
-      title = this.getTitleTemplateOutput_(features[i], layerId);
-      description = this.getDescriptionTemplateOutput_(features[i], layerId);
-
-      if (!title && !description) {
-        continue;
-      }
-
-      template = '<div class="ol-popup-item">';
-
-      if (title) {
-        template += '<div class="ol-popup__title">' + title + '</div>';
-      }
-
-      if (description) {
-        template += '<div class="ol-popup__description">' + description + '</div>';
-      }
-
-      template += '</div>';
-      this.info_.push(Mustache.render(template, features[i].getProperties()));
-    }
-  };
-
 })(jQuery, Drupal);
 

--- a/source/js/dg_maps.datalayerswitcher.js
+++ b/source/js/dg_maps.datalayerswitcher.js
@@ -98,9 +98,6 @@
     input.setAttribute('data-layer-id', layerId);
     inputWrapper.appendChild(input);
 
-    // TODO grey out layers which are not in range (not visible in extent).
-    // TODO also add event to check if changes.
-
     var label = document.createElement('label');
     label.htmlFor = lyrId;
     label.innerHTML = layer.get('title');

--- a/source/js/dg_maps.functions.js
+++ b/source/js/dg_maps.functions.js
@@ -1,4 +1,4 @@
-/* global ol, drupalSettings */
+/* global ol, drupalSettings, Mustache */
 /**
  * @file
  * DG Maps functionality extensions.
@@ -187,12 +187,15 @@
       features = [feature];
     }
 
-    var template, title, description;
+    var template;
+    var title;
+    var description;
+
     for (var i = 0; i < features.length; i++) {
       title = this.getTitleTemplateOutput_(features[i], layerId);
       description = this.getDescriptionTemplateOutput_(features[i], layerId);
 
-      if(!title && !description) {
+      if (!title && !description) {
         continue;
       }
 

--- a/source/js/dg_maps.functions.js
+++ b/source/js/dg_maps.functions.js
@@ -174,5 +174,42 @@
       })
       .first().click();
   };
+
+  /**
+   * Adds a feature as popup item to the internal popup items storage.
+   * @param {ol.Feature} feature The feature to add.
+   * @param {string} layerId The layer id the feature is from.
+   * @api
+   */
+  Drupal.dgMaps.ol.interaction.Popup.prototype.addFeature = function (feature, layerId) {
+    var features = feature.get('features');
+    if (typeof features === 'undefined') {
+      features = [feature];
+    }
+
+    var template, title, description;
+    for (var i = 0; i < features.length; i++) {
+      title = this.getTitleTemplateOutput_(features[i], layerId);
+      description = this.getDescriptionTemplateOutput_(features[i], layerId);
+
+      if(!title && !description) {
+        continue;
+      }
+
+      template = '<div class="ol-popup-item">';
+
+      if (title) {
+        template += '<div class="ol-popup__title">' + title + '</div>';
+      }
+
+      if (description) {
+        template += '<div class="ol-popup__description">' + description + '</div>';
+      }
+
+      template += '</div>';
+      this.info_.push(Mustache.render(template, features[i].getProperties()));
+    }
+  };
+
 })(jQuery, Drupal);
 

--- a/source/js/dg_maps.popup.js
+++ b/source/js/dg_maps.popup.js
@@ -1,4 +1,4 @@
-/* global ol, drupalSettings */
+/* global Mustache */
 /**
  * @file
  * DG Maps functionality extensions.

--- a/source/js/dg_maps.popup.js
+++ b/source/js/dg_maps.popup.js
@@ -1,0 +1,48 @@
+/* global ol, drupalSettings */
+/**
+ * @file
+ * DG Maps functionality extensions.
+ */
+(function ($, Drupal) {
+  'use strict';
+
+  /**
+   * Adds a feature as popup item to the internal popup items storage.
+   * @param {ol.Feature} feature The feature to add.
+   * @param {string} layerId The layer id the feature is from.
+   * @api
+   */
+  Drupal.dgMaps.ol.interaction.Popup.prototype.addFeature = function (feature, layerId) {
+    var features = feature.get('features');
+    if (typeof features === 'undefined') {
+      features = [feature];
+    }
+
+    var template;
+    var title;
+    var description;
+
+    for (var i = 0; i < features.length; i++) {
+      title = this.getTitleTemplateOutput_(features[i], layerId);
+      description = this.getDescriptionTemplateOutput_(features[i], layerId);
+
+      if (!title && !description) {
+        continue;
+      }
+
+      template = '<div class="ol-popup-item">';
+
+      if (title) {
+        template += '<div class="ol-popup__title">' + title + '</div>';
+      }
+
+      if (description) {
+        template += '<div class="ol-popup__description">' + description + '</div>';
+      }
+
+      template += '</div>';
+      this.info_.push(Mustache.render(template, features[i].getProperties()));
+    }
+  };
+})(jQuery, Drupal);
+

--- a/source/js/dg_maps.regions.js
+++ b/source/js/dg_maps.regions.js
@@ -1,4 +1,3 @@
-/* global ol, drupalSettings */
 /**
  * @file
  * DG Maps functionality extensions.

--- a/source/js/dg_maps.regions.js
+++ b/source/js/dg_maps.regions.js
@@ -1,0 +1,31 @@
+/* global ol, drupalSettings */
+/**
+ * @file
+ * DG Maps functionality extensions.
+ */
+(function ($, Drupal) {
+  'use strict';
+
+  var _initRegion = Drupal.dgMaps.initRegions;
+
+  /**
+   * Performs region initialisation.
+   * @param {Object} map - The map.
+   * @param {jQuery} mapElement - The map container element.
+   */
+  Drupal.dgMaps.initRegions = function (map, mapElement) {
+    _initRegion(map, mapElement);
+
+    // Close the legend by default
+    var mapContainer = mapElement.parents('.map-container');
+    var legendToggle = mapContainer.find('button[data-toggle-region="left"]');
+
+    legendToggle
+      .on('click', function () {
+        var region = $('.' + this.getAttribute('aria-controls'));
+        legendToggle.attr('aria-expanded', region.is(':visible'));
+      })
+      .first().click();
+  };
+})(jQuery, Drupal);
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Don't render an empty `<div>` for features with no title and/or description.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Empty `div` popups resulted in extra whitespace.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
- [x] I have ran gulp axe on the compiled files and found no errors.
