### PR TITLE
Bugfix: Fixed incorrect inner-box padding.

### DIFF
--- a/styleguide/components/11-base/boxes/_boxes.scss
+++ b/styleguide/components/11-base/boxes/_boxes.scss
@@ -74,7 +74,7 @@
   .inner-box {
 
     @include tablet {
-      padding-top: 4rem;
+      padding-top: 5rem;
 
       &::before {
         top: -3.5rem;

--- a/styleguide/components/11-base/boxes/_boxes.scss
+++ b/styleguide/components/11-base/boxes/_boxes.scss
@@ -72,10 +72,10 @@
 
 .box-top {
   .inner-box {
-    margin-bottom: 1.5rem;
-    padding-top: 4rem;
 
     @include tablet {
+      padding-top: 4rem;
+
       &::before {
         top: -3.5rem;
         right: 2rem;

--- a/styleguide/components/41-organisms/summary-box/_summary-box.scss
+++ b/styleguide/components/41-organisms/summary-box/_summary-box.scss
@@ -13,6 +13,11 @@
     }
   }
 
+  // Save room for the accolade
+  .inner-box {
+    margin-bottom: 1.5rem;
+  }
+
   .button {
     @include button-large;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Box-top had a different inner-box top padding compared to box-left.

## Motivation and Context

Bug

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/31842807/53400681-aeb98f80-39ae-11e9-8c3c-df78bd88f9e2.png)

After:
![image](https://user-images.githubusercontent.com/31842807/53400724-c55fe680-39ae-11e9-9bdd-93316f2e6482.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the style guide CHANGELOG accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
- [x] I have ran gulp axe on the compiled files and found no errors.
