### PR TITLE
DTGB-659: Fixed quote's text alignment

### DIFF
--- a/styleguide/components/31-molecules/quote/_quote.scss
+++ b/styleguide/components/31-molecules/quote/_quote.scss
@@ -32,12 +32,14 @@
       display: flex;
       position: relative;
       flex-wrap: wrap;
+      justify-content: center;
       align-items: center;
       min-height: 3rem;
       margin-top: 1rem;
 
       @include desktop {
         min-height: 6rem;
+        justify-content: initial;
       }
 
       &::before {

--- a/styleguide/components/31-molecules/quote/_quote.scss
+++ b/styleguide/components/31-molecules/quote/_quote.scss
@@ -32,14 +32,14 @@
       display: flex;
       position: relative;
       flex-wrap: wrap;
-      justify-content: center;
       align-items: center;
+      justify-content: center;
       min-height: 3rem;
       margin-top: 1rem;
 
       @include desktop {
-        min-height: 6rem;
         justify-content: initial;
+        min-height: 6rem;
       }
 
       &::before {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make sure the text in a quote is properly centered on mobile devices.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Whenever the text inside a quote was shorter than 1 line, it wasn't centered on mobile devices. 

## Screenshots (if appropriate):
![screenshot-2](https://user-images.githubusercontent.com/4415097/53717871-d353b280-3e59-11e9-837c-3047e1a31348.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the style guide CHANGELOG accordingly.
- [x] I have ran gulp axe on the compiled files and found no errors.
