### PR TITLE
DTGB-706: Fixed missing document link text when no file description is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * Tabs/local tasks theming
     > :warning: The tabs block should ideally be placed in the admin region. 
 
-
 ### Removed
 
 * DTGB-683: Frequently visited.
 * DTGB-700: [Styleguide](https://github.com/StadGent/fractal_styleguide_gent-base) as a part of gent-base. It is integrated as an npm dependency now.
+
+### Fixed
+
+* DTGB-706: Fixed missing document link text when no file description is set.
 
 ## [8.x-3.0-alpha11]
 

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -500,7 +500,11 @@ function gent_base_preprocess_file_link(&$variables) {
     $options['attributes']['class'][] = 'standalone-link';
     $options['attributes']['download'][] = 'download';
 
-    $variables['link'] = Link::fromTextAndUrl($variables['description'], Url::fromUri($url, $options));
+    // Use the filename as label if no description is set.
+    $label = !empty($variables['description'])
+      ? $variables['description']
+      : $file->getFilename();
+    $variables['link'] = Link::fromTextAndUrl($label, Url::fromUri($url, $options));
   }
 }
 

--- a/templates/contrib/facets/facets-summary-item-list.html.twig
+++ b/templates/contrib/facets/facets-summary-item-list.html.twig
@@ -66,4 +66,3 @@
     {{- empty -}}
   {%- endif -%}
 {%- endif %}
-

--- a/templates/custom/vesta/vesta.html.twig
+++ b/templates/custom/vesta/vesta.html.twig
@@ -162,4 +162,3 @@
   </div>
 </aside>
 {% endif %}
-


### PR DESCRIPTION
Fixed missing document label when no file description is set.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
