### PR TITLE
SGD8-828: Add form suggestion based on form_id (and not element ID)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * SGD8-546: Theming for webforms.
 * SGD8-546: Theming for default drupal throbber.
 
+### Updated
+
+* SGD8-828: Template suggestion for forms (they're now composed of 
+  "hook--form_id") instead of the element ID
+
+  > This should not be breaking since the element ID and form ID are identical
+    in 99% of the cases. 
+
 ## [8.x-3.0-beta1]
 
 ### Added

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -768,7 +768,7 @@ function gent_base_theme_suggestions_alter(array &$suggestions, array $variables
   $original_theme_hook = $variables['theme_hook_original'];
 
   if (isset($variables['element']['#type']) && $variables['element']['#type'] == 'form') {
-    $suggestions[] = $original_theme_hook . '__' . str_replace('-', '_', $variables['element']['#id']);
+    $suggestions[] = $original_theme_hook . '__' . str_replace('-', '_', $variables['element']['#form_id']);
   }
 
   if ($original_theme_hook === 'taxonomy_term') {

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -770,6 +770,10 @@ function gent_base_theme_suggestions_alter(array &$suggestions, array $variables
 
   if (isset($variables['element']['#type']) && $variables['element']['#type'] == 'form') {
     $suggestions[] = $original_theme_hook . '__' . str_replace('-', '_', $variables['element']['#form_id']);
+
+    if ($variables['element']['#form_id'] !== $variables['element']['#id']) {
+      $suggestions[] = $original_theme_hook . '__' . str_replace('-', '_', $variables['element']['#id']);
+    }
   }
 
   if ($original_theme_hook === 'taxonomy_term') {

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -365,8 +365,9 @@ function gent_base_preprocess_form_element(&$variables) {
     $element['#information'] = $element['#help'];
   }
 
-  if (isset($element['#description'])) {
+  if (isset($element['#description']) && isset($element['#webform'])) {
     $element['#information'] = $element['#description'];
+    unset($variables['description']);
   }
 
   $variables['in_fieldset'] = $element['#in_fieldset'] ?? NULL;

--- a/source/sass/11-base/forms/_forms.scss
+++ b/source/sass/11-base/forms/_forms.scss
@@ -26,3 +26,8 @@ textarea {
     margin-bottom: .4rem;
   }
 }
+
+.form-description {
+  @include theme('color', 'color-tertiary--lighten-1', 'form-description-color');
+  font-size: .6rem;
+}

--- a/templates/core/form/form-element.html.twig
+++ b/templates/core/form/form-element.html.twig
@@ -74,7 +74,7 @@
 %}
 {%
   set description_classes = [
-    'description',
+    'form-description',
     description_display == 'invisible' ? 'visually-hidden',
   ]
 %}
@@ -100,6 +100,7 @@
   <div class="form-columns">
     <div class="{{ has_row ? 'form-row' : 'form-item-column' }}">
   {% endif %}
+      <div class="{{ element['#type'] }}">
       {% if prefix is not empty %}
         <span class="field-prefix">{{ prefix }}</span>
       {% endif %}
@@ -110,6 +111,13 @@
       {% if label_display == 'after' %}
         {{ label }}
       {% endif %}
+
+      {% if description_display in ['after', 'invisible'] and description.content %}
+        <div{{ description.attributes.addClass(description_classes) }}>
+          {{ description.content }}
+        </div>
+      {% endif %}
+      </div>
 
     {% if not in_fieldset %}
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the template suggestion for forms in order to use the form_id instead of the id of the form element.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some modules modify the ID of the element (for example after submitting the form with ajax), which leads to faulty suggestions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
