### PR TITLE
SGD8-1024: Fix spacing around links in status messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
 * DTGB-652: Maps theming on mobile devices.
 * SGD8-828: Template suggestion for forms (they're now composed of
-  "hook--form_id") instead of the element ID
+  "hook--form_id") instead of the element ID.
 
   > This should not be breaking since the element ID and form ID are identical
     in 99% of the cases.
+
+### Fixed
+
+* SGD8-1024: Spacing around links in status messages.
 
 ## [8.x-3.0-beta1]
 

--- a/templates/core/misc/status-messages.html.twig
+++ b/templates/core/misc/status-messages.html.twig
@@ -52,7 +52,7 @@
           {% endfor %}
         </ul>
       {% else %}
-        {{ messages|first }}
+        <div>{{ messages|first }}</div>
       {% endif %}
     {% if type == 'error' %}
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix spacing around links in status messages


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since the messages component has `display: flex` the links were displayed as block-level elements.

**Styleguide**
```
<div class="messages">
	...
	<p>A very important message that you shouldn't miss</p>
</div>
```

**Drupal**
```
<div class="messages">
	...
	A very important message that you shouldn't miss
</div>
```

[Styleguide](https://github.com/StadGent/fractal_styleguide_gent-base) provides `p` tags around the actual text, but since drupal doesn't, we'll add a div around this content that acts as a flex child.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
