### PR TITLE
SGD8-1102: Fixed avatar in mijn-gent block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * SGD8-1102: Added correct link to profile in dg-auth block.
 * SGD8-629: Display checkbox popup over entire width of the page.
 * SGD8-629: Bind checkbox_filter only once.
+* SGD8-1102: Avatar for mijn-gent block.
 
 ## [8.x-3.0-beta1]
 

--- a/source/sass/31-molecules/mijn-gent-block/_mijn-gent-block.scss
+++ b/source/sass/31-molecules/mijn-gent-block/_mijn-gent-block.scss
@@ -2,4 +2,12 @@
   .login-link i {
     display: none;
   }
+
+  .avatar {
+    font-size: 0;
+
+    &::first-letter {
+      font-size: 1.2rem;
+    }
+  }
 }

--- a/templates/contrib/dg-auth/dg-auth-block.html.twig
+++ b/templates/contrib/dg-auth/dg-auth-block.html.twig
@@ -7,7 +7,6 @@
   ]
 %}
 
-
 <div{{ attributes.addClass(classes) }}>
   {% if login_link %}
     <div class="user-anonymous clearfix">
@@ -19,7 +18,7 @@
 
   <div class="user-logged-in">
     <button aria-expanded="false" aria-controls="mijn_gent_content" class="toggle accordion--button">
-      <img src="{{ default_picture_url }}" alt="{{ username }}" />
+      <span class="avatar">{{ username }}</span>
       <span>{{ username }}</span>
     </button>
 
@@ -27,7 +26,7 @@
       <div class="content">
         <h2>{{ 'Mijn Gent'|t }}</h2>
         <section class="profile">
-          <img src="{{ default_picture_url }}" alt="{{ username }}" />
+          <span class="avatar">{{ username }}</span>
           <div class="profile-info">
             <span>{{ username }}</span>
 

--- a/templates/contrib/dg-auth/dg-auth-block.html.twig
+++ b/templates/contrib/dg-auth/dg-auth-block.html.twig
@@ -18,7 +18,7 @@
 
   <div class="user-logged-in">
     <button aria-expanded="false" aria-controls="mijn_gent_content" class="toggle accordion--button">
-      <span class="avatar">{{ username }}</span>
+      <span class="avatar" aria-hidden="true">{{ username }}</span>
       <span>{{ username }}</span>
     </button>
 
@@ -26,7 +26,7 @@
       <div class="content">
         <h2>{{ 'Mijn Gent'|t }}</h2>
         <section class="profile">
-          <span class="avatar">{{ username }}</span>
+          <span class="avatar" aria-hidden="true">{{ username }}</span>
           <div class="profile-info">
             <span>{{ username }}</span>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Display avatar correctly in mijn-gent block. 

> **⚠️ NOTE:** since the username is filled in dynamically, the first letter of the username cannot be extracted in the twig template. Therefore, we display the entire username, then hide all text except the first letter in CSS.

## Screenshots (if appropriate):
<img width="330" alt="Screenshot 2019-06-14 at 12 33 23" src="https://user-images.githubusercontent.com/4415097/59503411-9d828900-8ea0-11e9-99ec-a88bfa8d93fc.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
