### PR TITLE
DTGB-722: Added missing translation configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * SGD8-629: Display checkbox popup over entire width of the page.
 * SGD8-629: Bind checkbox_filter only once.
 * SGD8-1102: Avatar for mijn-gent block.
+* DTGB-722: Added missing translation configuration.
 
 ## [8.x-3.0-beta1]
 

--- a/starterkit/starterkit.info.yml
+++ b/starterkit/starterkit.info.yml
@@ -15,3 +15,6 @@ regions:
   header_bottom: Header bottom
   content: Content
   footer: Footer
+
+'interface translation project': starterkit
+'interface translation server pattern': themes/custom/%project/translations/%language.po

--- a/templates/contrib/facets/facets-summary-item-list.html.twig
+++ b/templates/contrib/facets/facets-summary-item-list.html.twig
@@ -66,4 +66,3 @@
     {{- empty -}}
   {%- endif -%}
 {%- endif %}
-

--- a/templates/custom/vesta/vesta.html.twig
+++ b/templates/custom/vesta/vesta.html.twig
@@ -162,4 +162,3 @@
   </div>
 </aside>
 {% endif %}
-


### PR DESCRIPTION
The starterkit configuration (`starterkit.yml`) does not have the translations configuration.
Due to that missing configuration, no translations are imported from it.

## Description

* Added config.
* Fixed code style in templates.

## Motivation and Context

Avoid translations not loaded due to example subtheme with missing example.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
