### PR TITLE
DTGB-725: Fixed warning when previewing newly created node with paragraphs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
+## [Unreleased]
+
+### Fixed
+
+* DTGB-725: Fixed warning when previewing newly created node with paragraphs.
+
 ## [8.x-3.0-beta2]
 
 ### Added

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -401,7 +401,12 @@ function gent_base_preprocess_field(&$variables) {
     $isProgram = FALSE;
 
     foreach ($paragraphs as $key => $paragraph) {
-      $entity = Paragraph::load($paragraph->get('target_id')->getValue());
+      $targetId = $paragraph->get('target_id')->getValue();
+      if (!$targetId) {
+        continue;
+      }
+
+      $entity = Paragraph::load($targetId);
       if ($entity) {
         $type = $entity->get('type')->getString();
 


### PR DESCRIPTION
Fixes warnings when previewing new node with paragraph content.

## Description

When a new node with paragraphs is previewed:

* The node has no id yet.
* The paragraphs have no target id yet.

The `gent_base_preprocess_field()` methode tries to load the target entity without checking if there is a valid ID to load it with.

## Motivation and Context

Bugfix.

## How Has This Been Tested?

User test.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.

