### PR TITLE
Replace manifest.json with its successor site.webmanifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 ### Fixed
 
 * DTGB-725: Fixed warning when previewing newly created node with paragraphs.
+* Fix 404 error for `manifest.json` (it is renamed to `site.webmanifest`)
 
 ## [8.x-3.0-beta2]
 

--- a/templates/core/layout/html.html.twig
+++ b/templates/core/layout/html.html.twig
@@ -41,7 +41,7 @@
       <link rel="apple-touch-icon" sizes="180x180" href="{{ base_path }}themes/contrib/gent_base/build/styleguide/img/favicon/build/{{ cs.color }}/apple-touch-icon.png" />
       <link rel="icon" type="image/png" sizes="32x32" href="{{ base_path }}themes/contrib/gent_base/build/styleguide/img/favicon/build/{{ cs.color }}/favicon-32x32.png" />
       <link rel="icon" type="image/png" sizes="16x16" href="{{ base_path }}themes/contrib/gent_base/build/styleguide/img/favicon/build/{{ cs.color }}/favicon-16x16.png" />
-      <link rel="manifest" href="{{ base_path }}themes/contrib/gent_base/build/styleguide/img/favicon/build/{{ cs.color }}/manifest.json" />
+      <link rel="manifest" href="{{ base_path }}themes/contrib/gent_base/build/styleguide/img/favicon/build/{{ cs.color }}/site.webmanifest" />
       <link rel="mask-icon" href="{{ base_path }}themes/contrib/gent_base/build/styleguide/img/favicon/build/{{ cs.color }}/safari-pinned-tab.svg" color="{{ cs.hex }}" />
       <meta name="msapplication-TileColor" content="{{ cs.hex }}" />
       <meta name="theme-color" content="{{ cs.hex }}" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`real-favicon-generator` has renamed the manifest file, which resulted in loading a non-existing file `manifest.json`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As stated in [the spec](https://www.w3.org/TR/appmanifest/), the manifest should be defined as a `.manifest` file. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
