### PR TITLE
DTGB-730: Fixed fatal error when visiting page with closed webform.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * Added extra checks for field existence in call-to-action.
 * Fix 404 error for `manifest.json` (it is renamed to `site.webmanifest`).
 * Theming for status messages.
-* Fixed JS error when popup feature isn't enabled in dg_maps
+* Fixed JS error when popup feature isn't enabled in dg_maps.
+* DTGB-730: Fixed fatal error when visiting page with closed webform.
 
 ### Removed
 

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -66,7 +66,7 @@ function gent_base_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  *   Altered build array.
  */
 function _gent_base_webform_pre_render(array $form) {
-  $form['#has_inputs'] = false;
+  $form['#has_inputs'] = FALSE;
   if (empty($form['elements'])) {
     return $form;
   }

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -66,26 +66,26 @@ function gent_base_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  *   Altered build array.
  */
 function _gent_base_webform_pre_render(array $form) {
+    $form['#has_inputs'] = false;
 
-  if (isset($form['elements'])) {
-    _gent_base_loop_webform_elements($form['elements']);
-  }
-
-  $form['#webform'] = $webform = Webform::load($form['#webform_id']);
-
-  // Check if the form has input fields.
-  if ($webform->hasWizardPages() && isset($form['progress'])) {
-    $current_page = $form['progress']['#current_page'];
-
-    if ($current_page && isset($form['elements'][$current_page])) {
-      $form['#has_inputs'] = _gent_base_count_webform_inputs($form['elements'][$current_page]) > 0;
+    if (empty($form['elements'])) {
+        return $form;
     }
-  }
-  else {
-    $form['#has_inputs'] = _gent_base_count_webform_inputs($form['elements']) > 0;
-  }
 
-  return $form;
+    _gent_base_loop_webform_elements($form['elements']);
+    $elements = $form['elements'];
+
+    // If this is a multistep form > get the elements of the current step.
+    $form['#webform'] = $webform = Webform::load($form['#webform_id']);
+    if ($webform->hasWizardPages() && isset($form['progress'])) {
+        $current_page = $form['progress']['#current_page'];
+        $elements = $current_page && !empty($form['elements'][$current_page])
+            ? $form['elements'][$current_page]
+            : [];
+    }
+    $form['#has_inputs'] = (bool) _gent_base_count_webform_inputs($elements);
+
+    return $form;
 }
 
 /**

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -66,26 +66,25 @@ function gent_base_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  *   Altered build array.
  */
 function _gent_base_webform_pre_render(array $form) {
-    $form['#has_inputs'] = false;
-
-    if (empty($form['elements'])) {
-        return $form;
-    }
-
-    _gent_base_loop_webform_elements($form['elements']);
-    $elements = $form['elements'];
-
-    // If this is a multistep form > get the elements of the current step.
-    $form['#webform'] = $webform = Webform::load($form['#webform_id']);
-    if ($webform->hasWizardPages() && isset($form['progress'])) {
-        $current_page = $form['progress']['#current_page'];
-        $elements = $current_page && !empty($form['elements'][$current_page])
-            ? $form['elements'][$current_page]
-            : [];
-    }
-    $form['#has_inputs'] = (bool) _gent_base_count_webform_inputs($elements);
-
+  $form['#has_inputs'] = false;
+  if (empty($form['elements'])) {
     return $form;
+  }
+
+  _gent_base_loop_webform_elements($form['elements']);
+  $elements = $form['elements'];
+
+  // If this is a multistep form > get the elements of the current step.
+  $form['#webform'] = $webform = Webform::load($form['#webform_id']);
+  if ($webform->hasWizardPages() && isset($form['progress'])) {
+    $current_page = $form['progress']['#current_page'];
+    $elements = $current_page && !empty($form['elements'][$current_page])
+      ? $form['elements'][$current_page]
+      : [];
+  }
+  $form['#has_inputs'] = (bool) _gent_base_count_webform_inputs($elements);
+
+  return $form;
 }
 
 /**


### PR DESCRIPTION
Fatal error when accessing closed webform.

## Description

When a visitor accesses a webform that is closed (or planed in the future), a fatal error is thrown:

```
Argument 1 passed to _gent_base_count_webform_inputs() must be of the type array, null given, called in web/themes/contrib/gent_base/gent_base.theme on line 85
```

This because there are no form elements.

## Motivation and Context

Blocking issue that results in broken web pages.

## How Has This Been Tested?

Manually tested.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
