### PR TITLE
DTGB-769: Fixed broken documents field accordion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
 * Make "optional" label controllable through [State API](https://www.drupal.org/docs/8/api/state-api/).
 * Duplicate ID's in table list descriptions.
+* DTGB-769: Fixed broken documents field accordion. 
 
 ## [8.x-3.0-beta7]
 

--- a/templates/core/fields/field--field-documents.html.twig
+++ b/templates/core/fields/field--field-documents.html.twig
@@ -38,6 +38,8 @@
  */
 #}
 
+{{ attach_library('gent_base/accordion') }}
+
 {%
   set title_classes = [
     'field__label',
@@ -56,17 +58,19 @@
 </ul>
 
 {% if items|length > 2 %}
-  <h3>
-    <button class="accordion--button" aria-expanded="false" aria-controls="documents--content--{{ document_unique_id }}">
-      {{ documents_toggle_text }}
-    </button>
-  </h3>
+  <div class="accordion">
+    <h3>
+      <button class="accordion--button" aria-expanded="false" aria-controls="documents--content--{{ document_unique_id }}">
+        {{ documents_toggle_text }}
+      </button>
+    </h3>
 
-  <div class="accordion--content" id="documents--content--{{ document_unique_id }}" aria-hidden="true" hidden="true">
-    <ul class="links">
-      {% for document in documents_invisible %}
-        <li>{{ document }}</li>
-      {% endfor %}
-    </ul>
+    <div class="accordion--content" id="documents--content--{{ document_unique_id }}" aria-hidden="true" hidden="true">
+      <ul class="links">
+        {% for document in documents_invisible %}
+          <li>{{ document }}</li>
+        {% endfor %}
+      </ul>
+    </div>
   </div>
 {% endif %}


### PR DESCRIPTION
Accordion not working in documents field.

## Description

When a documents field is added (for example in a paragraph) and it contains more than 2 documents, the other documents are hidden in an accordion.

The opening / closing of this accordion does not work (anymore).

## Motivation and Context

Bug

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
