### PR TITLE
KAG-117: Loop form elements for all forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * Removed rel attribute from read more links.
 * Updated CSS classes in dg_auth block.
 
+* Form elements are looped for all forms now. It is not restricted to webforms
+  anymore.
+
 ### Fixed
 
 * Make "optional" label controllable through [State API](https://www.drupal.org/docs/8/api/state-api/).
 * Duplicate ID's in table list descriptions.
-* DTGB-769: Fixed broken documents field accordion. 
+* DTGB-769: Fixed broken documents field accordion.
 
 ## [8.x-3.0-beta7]
 

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -51,9 +51,10 @@ function gent_base_form_alter(&$form, FormStateInterface $form_state, $form_id) 
   }
 
   if (isset($form['#webform_id'])) {
-    $form['#pre_render'][] = '_gent_base_webform_pre_render';
     $form['#theme'] = ['gent_base_webform'];
   }
+
+  $form['#pre_render'][] = '_gent_base_form_pre_render';
 }
 
 /**
@@ -65,24 +66,27 @@ function gent_base_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  * @return mixed
  *   Altered build array.
  */
-function _gent_base_webform_pre_render(array $form) {
+function _gent_base_form_pre_render(array $form) {
   $form['#has_inputs'] = FALSE;
-  if (empty($form['elements'])) {
-    return $form;
+  $elements = &$form;
+  if (!empty($form['elements'])) {
+    $elements = &$form['elements'];
   }
 
-  _gent_base_loop_webform_elements($form['elements']);
-  $elements = $form['elements'];
+  _gent_base_loop_form_elements($elements);
 
   // If this is a multistep form > get the elements of the current step.
-  $form['#webform'] = $webform = Webform::load($form['#webform_id']);
-  if ($webform->hasWizardPages() && isset($form['progress'])) {
-    $current_page = $form['progress']['#current_page'];
-    $elements = $current_page && !empty($form['elements'][$current_page])
-      ? $form['elements'][$current_page]
-      : [];
+  if (isset($form['#webform_id'])) {
+    $form['#webform'] = $webform = Webform::load($form['#webform_id']);
+    if ($webform->hasWizardPages() && isset($form['progress'])) {
+      $current_page = $form['progress']['#current_page'];
+      $elements = $current_page && !empty($form['elements'][$current_page])
+        ? $form['elements'][$current_page]
+        : [];
+    }
   }
-  $form['#has_inputs'] = (bool) _gent_base_count_webform_inputs($elements);
+
+  $form['#has_inputs'] = (bool) _gent_base_count_inputs($elements);
 
   return $form;
 }

--- a/includes/form.inc
+++ b/includes/form.inc
@@ -16,7 +16,7 @@ use Drupal\Core\Render\Element;
  * @return int
  *   The number of input fields counted.
  */
-function _gent_base_count_webform_inputs(array $elements) {
+function _gent_base_count_inputs(array $elements) {
   $children = Element::children($elements);
   $input_count = 0;
 
@@ -43,11 +43,11 @@ function _gent_base_count_webform_inputs(array $elements) {
  * @param array $elements
  *   Build array for the elements that have to be altered.
  */
-function _gent_base_loop_webform_elements(array &$elements) {
+function _gent_base_loop_form_elements(array &$elements) {
   $children = Element::children($elements);
 
   if ($children === ['elements']) {
-    _gent_base_loop_webform_elements($elements['elements']);
+    _gent_base_loop_form_elements($elements['elements']);
     return;
   }
 
@@ -57,13 +57,13 @@ function _gent_base_loop_webform_elements(array &$elements) {
       continue;
     }
 
-    _gent_base_loop_webform_elements_options($element);
-    _gent_base_loop_webform_elements_options_other($element);
-    _gent_base_loop_webform_elements_email_confirm($element);
-    _gent_base_loop_webform_elements_datetime($element);
-    _gent_base_loop_webform_elements_select_other($element);
-    _gent_base_loop_webform_elements_markup($element);
-    _gent_base_loop_webform_elements_upload($element);
+    _gent_base_loop_form_elements_options($element);
+    _gent_base_loop_form_elements_options_other($element);
+    _gent_base_loop_form_elements_email_confirm($element);
+    _gent_base_loop_form_elements_datetime($element);
+    _gent_base_loop_form_elements_select_other($element);
+    _gent_base_loop_form_elements_markup($element);
+    _gent_base_loop_form_elements_upload($element);
     _gent_base_loop_webform_group($element);
   }
 }
@@ -74,7 +74,7 @@ function _gent_base_loop_webform_elements(array &$elements) {
  * @param array $element
  *   Build array a form element.
  */
-function _gent_base_loop_webform_elements_options(array &$element) {
+function _gent_base_loop_form_elements_options(array &$element) {
   $optionTypes = ['checkboxes', 'radios'];
   if (!in_array($element['#type'], $optionTypes)) {
     return;
@@ -93,13 +93,13 @@ function _gent_base_loop_webform_elements_options(array &$element) {
  * @param array $element
  *   Build array a form element.
  */
-function _gent_base_loop_webform_elements_options_other(array &$element) {
+function _gent_base_loop_form_elements_options_other(array &$element) {
   $optionTypes = ['webform_checkboxes_other', 'webform_radios_other'];
   if (!in_array($element['#type'], $optionTypes)) {
     return;
   }
 
-  _gent_base_loop_webform_elements($element);
+  _gent_base_loop_form_elements($element);
 
   $element['#has_columns'] = TRUE;
   $element['other']['#parent_type'] = $element['#type'];
@@ -112,7 +112,7 @@ function _gent_base_loop_webform_elements_options_other(array &$element) {
  * @param array $element
  *   Build array a form element.
  */
-function _gent_base_loop_webform_elements_email_confirm(array &$element) {
+function _gent_base_loop_form_elements_email_confirm(array &$element) {
   if ($element['#type'] !== 'webform_email_confirm') {
     return;
   }
@@ -130,7 +130,7 @@ function _gent_base_loop_webform_elements_email_confirm(array &$element) {
  * @param array $element
  *   Build array a form element.
  */
-function _gent_base_loop_webform_elements_datetime(array &$element) {
+function _gent_base_loop_form_elements_datetime(array &$element) {
   if ($element['#type'] !== 'datetime') {
     return;
   }
@@ -147,7 +147,7 @@ function _gent_base_loop_webform_elements_datetime(array &$element) {
  * @param array $element
  *   Build array a form element.
  */
-function _gent_base_loop_webform_elements_select_other(array &$element) {
+function _gent_base_loop_form_elements_select_other(array &$element) {
   if ($element['#type'] !== 'webform_select_other') {
     return;
   }
@@ -165,7 +165,7 @@ function _gent_base_loop_webform_elements_select_other(array &$element) {
  * @param array $element
  *   Build array a form element.
  */
-function _gent_base_loop_webform_elements_markup(array &$element) {
+function _gent_base_loop_form_elements_markup(array &$element) {
   if ($element['#type'] !== 'webform_markup') {
     return;
   }
@@ -185,7 +185,7 @@ function _gent_base_loop_webform_group(array &$element) {
     return;
   }
 
-  _gent_base_loop_webform_elements($element);
+  _gent_base_loop_form_elements($element);
 }
 
 /**
@@ -194,7 +194,7 @@ function _gent_base_loop_webform_group(array &$element) {
  * @param array $element
  *   Build array a form element.
  */
-function _gent_base_loop_webform_elements_upload(array &$element) {
+function _gent_base_loop_form_elements_upload(array &$element) {
   $uploadTypes = ['webform_image_file', 'webform_document_file'];
   if (!in_array($element['#type'], $uploadTypes)) {
     return;

--- a/source/sass/41-organisms/footer/_footer.scss
+++ b/source/sass/41-organisms/footer/_footer.scss
@@ -1,0 +1,3 @@
+.region-footer {
+  margin-top: 4rem;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Form elements are looped for all forms now. It is not restricted to webforms anymore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before, the form elements were altered for webforms in order to display them in a correct way: option fields were grouped together, datetime fields were displayed next to each other, etc. 

Since these changes were not applied to custom forms, the display didn't correspond to webforms.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In the Kot@Gent project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
