### PR TITLE
Release 8.x-3.0-beta11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * Theme wrapper "form_element_bare".
 * ID attribute for map regions.
 * Label to close button in map legend.
+* Template for local actions block.
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 ### Added
 
 * Partner paragraph.
+* ID attribute for map regions.
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
+## [Unreleased]
+
+* Partner paragraph.
+
 ## [8.x-3.0-beta9]
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * Optimize aria attributes for image galleries.
 * Added `role="alert"` to error messages.
 
+### Fixed
+
+* Missing label for dropdown facets.
+
 ## [8.x-3.0-beta9]
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 ### Added
 
 * Partner paragraph.
+* Theme wrapper "form_element_bare".
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * Optimize aria attributes for image galleries.
 * Added `role="alert"` to error messages.
 
+### Fixed
+
+* Broken focus outline for map controls.
+
 ## [8.x-3.0-beta9]
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
-## [Unreleased]
+## [8.x-3.0-beta11]
 
 ### Added
 
@@ -319,7 +319,8 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
 * **Updated to gent_styleguide version 2.6.13**
 
-[8.x-3.0-beta9]: https://github.com/StadGent/drupal_theme_gent-base/compare/8.x-3.0-beta9...8.x-3.0-beta10
+[8.x-3.0-beta11]: https://github.com/StadGent/drupal_theme_gent-base/compare/8.x-3.0-beta10...8.x-3.0-beta11
+[8.x-3.0-beta10]: https://github.com/StadGent/drupal_theme_gent-base/compare/8.x-3.0-beta9...8.x-3.0-beta10
 [8.x-3.0-beta9]: https://github.com/StadGent/drupal_theme_gent-base/compare/8.x-3.0-beta8...8.x-3.0-beta9
 [8.x-3.0-beta8]: https://github.com/StadGent/drupal_theme_gent-base/compare/8.x-3.0-beta7...8.x-3.0-beta8
 [8.x-3.0-beta7]: https://github.com/StadGent/drupal_theme_gent-base/compare/8.x-3.0-beta6...8.x-3.0-beta7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
 * Missing label for dropdown facets.
 * Broken focus outline for map controls.
+* Modal layout for filters.
 
 ## [8.x-3.0-beta10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * Missing label for dropdown facets.
 * Broken focus outline for map controls.
 * Modal layout for filters.
+* Fixed typo in table-mobile script that caused JS error in Safari.
 
 ## [8.x-3.0-beta10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
 ## [Unreleased]
 
+### Added
+
 * Partner paragraph.
+
+### Updated
+
+* Optimize aria attributes for image galleries.
+* Added `role="alert"` to error messages.
 
 ## [8.x-3.0-beta9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * Theme wrapper "form_element_bare".
 * ID attribute for map regions.
 * Label to close button in map legend.
+* Force `alt` attribute for images, even if it's empty.
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 * Broken focus outline for map controls.
 * Modal layout for filters.
 * Fixed typo in table-mobile script that caused JS error in Safari.
+* `aria-labelledby` on mobile tables when no caption is present.
 
 ## [8.x-3.0-beta10]
 

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -1087,3 +1087,13 @@ function gent_base_preprocess_dg_maps_map(&$variables) {
 function gent_base_preprocess_form_element_bare(&$variables) {
   template_preprocess_form_element($variables);
 }
+
+/**
+ * Implements hook_preprocess_image().
+ */
+function gent_base_preprocess_image(&$variables) {
+  $attributes = &$variables['attributes'];
+  if (!isset($attributes['alt']) || !$attributes['alt']) {
+    $attributes['alt'] = "";
+  }
+}

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -25,6 +25,9 @@ function gent_base_theme() {
     'gent_base_webform' => [
       'render element' => 'form',
     ],
+    'form_element_bare' => [
+      'render element' => 'element',
+    ],
   ];
 }
 
@@ -308,10 +311,8 @@ function gent_base_preprocess_block__views_search_form_header(&$variables) {
   $form = &$variables['content'];
 
   if ($form['#form_id'] === 'views_exposed_form') {
-    $form['search']['#theme_wrappers'] = [];
     $form['search']['#value'] = NULL;
     $form['search']['#required'] = TRUE;
-    $form['actions']['#theme_wrappers'] = [];
 
     $form['#prefix'] = '<a href="' . $form['#action'] . '" class="search--link" title="' . t('Search') . '">' . t('Search') . '</a>';
   }
@@ -1078,4 +1079,11 @@ function gent_base_preprocess_dg_maps_map(&$variables) {
     'img_base' => drupal_get_path('theme', 'gent_base') . '/source/img/',
     'legend_title' => t('View on the map'),
   ];
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function gent_base_preprocess_form_element_bare(&$variables) {
+  template_preprocess_form_element($variables);
 }

--- a/source/js/dg_maps.datalayerswitcher.js
+++ b/source/js/dg_maps.datalayerswitcher.js
@@ -52,6 +52,7 @@
 
       this.toggle = document.createElement('button');
       this.toggle.setAttribute('data-toggle-region', 'left');
+      this.toggle.textContent = Drupal.t('Close');
       this.iconIcon = document.createElement('i');
       this.iconIcon.className = 'icon-chevron-left';
       this.toggle.appendChild(this.iconIcon);
@@ -150,4 +151,3 @@
 
   Drupal.dgMaps.ol.control.DataLayerSwitcher.prototype = originalPrototype;
 })(jQuery, Drupal);
-

--- a/source/js/filter.bindings.js
+++ b/source/js/filter.bindings.js
@@ -16,7 +16,7 @@
       new Modal(filter, {
         // The modal is always visible from tablet and up,
         // this is atypical.
-        resizeEvent: (open, close) => {
+        resizeEvent: function (open, close) {
           if (window.innerWidth > 960) {
             close();
             filter.setAttribute('aria-hidden', 'false');

--- a/source/js/filter.bindings.js
+++ b/source/js/filter.bindings.js
@@ -16,12 +16,12 @@
       new Modal(filter, {
         // The modal is always visible from tablet and up,
         // this is atypical.
-        resizeEvent: function resizeEvent() {
-          if (window.innerWidth > 768) {
+        resizeEvent: (open, close) => {
+          if (window.innerWidth > 960) {
+            close();
             filter.setAttribute('aria-hidden', 'false');
-            document.body.style.overflow = '';
           }
-          else {
+          else if (!filter.classList.contains('visible')) {
             filter.setAttribute('aria-hidden', 'true');
           }
         }

--- a/source/js/table-mobile.functions.js
+++ b/source/js/table-mobile.functions.js
@@ -77,7 +77,7 @@
      */
     var addListItems = function (list) {
       // Get the headers of the table columns.
-      var colHeadingsNodeList = element.querySelector('table').querySelectorAll('th[scope="col"');
+      var colHeadingsNodeList = element.querySelector('table').querySelectorAll('th[scope="col"]');
       // Get the headers of the table rows.
       var rowHeadingsNodeList = element.querySelector('table').querySelectorAll('th[scope="row"]');
       // Get all rows of the table.

--- a/source/js/table-mobile.functions.js
+++ b/source/js/table-mobile.functions.js
@@ -46,7 +46,6 @@
 
       return options;
     })();
-
     var id = (function () {
       var base = 'list-description';
       var elements = [].slice.call(document.querySelectorAll('[id*="' + base + '"'));
@@ -63,7 +62,9 @@
     var addTableList = function () {
       tableList = document.createElement('div');
       tableList.classList.add('table-list');
-      tableList.setAttribute('aria-labelledby', id);
+      if (caption) {
+        tableList.setAttribute('aria-labelledby', id);
+      }
       element.parentNode.parentNode.insertBefore(tableList, element.nextSibling);
 
       addList();

--- a/source/sass/31-molecules/facets/_facets.scss
+++ b/source/sass/31-molecules/facets/_facets.scss
@@ -1,3 +1,7 @@
 .facet-empty {
   display: none;
 }
+
+.facets-widget-dropdown label {
+  display: block;
+}

--- a/source/sass/31-molecules/local-tasks/_local-tasks.scss
+++ b/source/sass/31-molecules/local-tasks/_local-tasks.scss
@@ -13,3 +13,7 @@
     margin: 0 .3rem .3rem;
   }
 }
+
+.action-links {
+  margin-bottom: 2rem;
+}

--- a/source/sass/31-molecules/map/_map.scss
+++ b/source/sass/31-molecules/map/_map.scss
@@ -357,6 +357,7 @@ $map-text-color: color('dark-gray');
 
   &-region {
     z-index: 5;
+    overflow: visible;
 
     &--right-top {
       top: $map-padding;

--- a/source/sass/31-molecules/map/_map.scss
+++ b/source/sass/31-molecules/map/_map.scss
@@ -363,6 +363,15 @@ $map-text-color: color('dark-gray');
     z-index: 5;
     overflow: visible;
 
+    &--left {
+      // This should be applied only the exact viewport of 768px. Since the 3rd
+      // party package uses max-width instead of min-width, it is not applied to
+      // this viewport.
+      @media (width: 768px) {
+        width: 300px;
+      }
+    }
+
     &--right-top {
       top: $map-padding;
       right: $map-padding;

--- a/source/sass/31-molecules/map/_map.scss
+++ b/source/sass/31-molecules/map/_map.scss
@@ -108,7 +108,11 @@ $map-text-color: color('dark-gray');
           min-height: 1em;
           background: transparent;
           color: inherit;
-          font-size: 1.5em;
+          font-size: 0;
+
+          i {
+            font-size: 1.2rem;
+          }
         }
       }
 

--- a/source/sass/31-molecules/partner-block/_partner-block.scss
+++ b/source/sass/31-molecules/partner-block/_partner-block.scss
@@ -1,0 +1,12 @@
+.partner-block {
+  .partners {
+    width: 100%;
+  }
+
+  .partners,
+  .single-partner {
+    a::after {
+      display: none;
+    }
+  }
+}

--- a/source/sass/31-molecules/search/_search.scss
+++ b/source/sass/31-molecules/search/_search.scss
@@ -9,6 +9,10 @@
     flex-shrink: 0;
   }
 
+  label {
+    @extend %visually-hidden;
+  }
+
   input[type='text'] {
     background-color: color('white');
     @extend %search-input;

--- a/templates/contrib/dg_maps/dg-maps-map-region.html.twig
+++ b/templates/contrib/dg_maps/dg-maps-map-region.html.twig
@@ -15,6 +15,7 @@
   </button>
 {% endif %}
 
-<div class="{{ region_classes|join(' ') }}{{ hide_on_mobile }}" data-region="{{ name }}">
+<div {{ name ? 'id="map-region--' ~ name ~ '"' }} class="{{ region_classes|join(' ') }}{{ hide_on_mobile }}" data-region="{{ name }}">
+
   {{ content }}
 </div>

--- a/templates/contrib/facets/facets-item-list--dropdown.html.twig
+++ b/templates/contrib/facets/facets-item-list--dropdown.html.twig
@@ -24,13 +24,13 @@
  * @ingroup themeable
  */
 #}
-<fieldset class="form-item facets-widget- {{- facet.widget.type -}} ">
+<div class="form-item facets-widget- {{- facet.widget.type -}} ">
   {% if facet.widget.type %}
     {%- set attributes = attributes.addClass('item-list__' ~ facet.widget.type) %}
   {% endif %}
   {% if items or empty %}
     {%- if title is not empty -%}
-      <legend for="{{ facet.id }}">{{ title }}</legend>
+      <label for="{{ facet.id }}">{{ title }}</label>
     {%- endif -%}
 
     {%- if items -%}
@@ -43,4 +43,4 @@
       {{- empty -}}
     {%- endif -%}
   {%- endif %}
-</fieldset>
+</div>

--- a/templates/contrib/paragraphs/partners/paragraph--partners.html.twig
+++ b/templates/contrib/paragraphs/partners/paragraph--partners.html.twig
@@ -1,0 +1,58 @@
+{#
+/**
+ * @file
+ * Theme implementation to display a links paragraph (list of link paragraphs).
+ *
+ * Available variables:
+ * - grid_size: The number of items in each grid row.
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% extends 'paragraph.html.twig' %}
+
+{% block paragraph %}
+  {% set classes = classes|merge([
+    'highlight',
+    'partner-block'
+  ]) %}
+
+  {{ parent() }}
+{% endblock %}
+
+{% block content %}
+  <div class="highlight__inner">
+    {{ parent() }}
+  </div>
+{% endblock %}

--- a/templates/core/block/block--local-actions-block.html.twig
+++ b/templates/core/block/block--local-actions-block.html.twig
@@ -1,0 +1,16 @@
+{% extends "block.html.twig" %}
+{#
+/**
+ * @file
+ * Theme override for local actions (primary admin actions.)
+ */
+#}
+{% block content %}
+  {% if content %}
+    <nav class="action-links">
+      <ul class="inline">
+        {{ content }}
+      </ul>
+    </nav>
+  {% endif %}
+{% endblock %}

--- a/templates/core/fields/field--paragraph--field-paragraphs--partners.html.twig
+++ b/templates/core/fields/field--paragraph--field-paragraphs--partners.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+    'inline',
+  ]
+%}
+
+{% if items|length > 1 %}
+  <div class="partners">
+    <ul{{attributes.addClass('inline')}}>
+      {% for item in items %}
+        <li{{item.attributes}}>{{ item.content }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+{% else %}
+  <div class="single-partner">
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  </div>
+{% endif %}

--- a/templates/core/fields/field--paragraph--title--partners.html.twig
+++ b/templates/core/fields/field--paragraph--title--partners.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% for item in items %}
+  <h3>{{ item.content }}</h3>
+{% endfor %}

--- a/templates/core/form/fieldset.html.twig
+++ b/templates/core/form/fieldset.html.twig
@@ -55,7 +55,7 @@
   {%  endif %}
 
   {% if errors and not has_columns %}
-    <div class="field-message error">
+    <div class="field-message error" role="alert">
       {{ errors }}
       <div class="accolade"></div>
     </div>
@@ -79,7 +79,7 @@
     {% if has_columns %}
     <div class="form-item-column">
       {% if errors %}
-        <div class="field-message error">
+        <div class="field-message error" role="alert">
           {{ errors }}
           <div class="accolade"></div>
         </div>

--- a/templates/core/form/form-element.html.twig
+++ b/templates/core/form/form-element.html.twig
@@ -137,7 +137,7 @@
     {% endif %}
     <div class="form-item-column">
       {% if errors %}
-          <div class="field-message error">
+          <div class="field-message error" role="alert">
             {{ errors }}
             <div class="accolade"></div>
           </div>

--- a/templates/core/layout/region--filters.html.twig
+++ b/templates/core/layout/region--filters.html.twig
@@ -37,5 +37,6 @@
         <button type="button" class="button button-primary modal-close filter-show-results-button" data-target="filter">{{ 'Show results'|t }}</button>
       </div>
     </div>
+    <div class="modal-overlay modal-close" data-target="filter" tabindex="-1"></div>
   </section>
 {% endif %}

--- a/templates/custom/media/media--image--gallery-multiple.html.twig
+++ b/templates/custom/media/media--image--gallery-multiple.html.twig
@@ -16,11 +16,9 @@
 <a{{ attributes }}
   href="{{ gallery_full_url|default(file_url(content.field_media_image.0['#item'].entity.uri.value)) }}"
   class="gallery-link"
+  aria-describedby="image-gallery__open-gallery"
   {% if not media.field_media_caption.isEmpty %}
     aria-label="{{ media.field_media_caption.value }}"
-    aria-describedby="image-gallery__open-gallery"
-  {% else %}
-    aria-labelledby="image-gallery__open-gallery"
   {% endif %}
   >
   {{ title_suffix.contextual_links }}

--- a/templates/custom/media/media--image--gallery-single.html.twig
+++ b/templates/custom/media/media--image--gallery-single.html.twig
@@ -16,11 +16,9 @@
 <a{{ attributes }}
   href="{{ gallery_full_url|default(file_url(content.field_media_image.0['#item'].entity.uri.value)) }}"
   class="gallery-link"
+  aria-describedby="image-gallery__open-gallery"
   {% if not media.field_media_caption.isEmpty %}
   aria-label="{{ media.field_media_caption.value }}"
-  aria-describedby="image-gallery__open-gallery"
-  {% else %}
-  aria-labelledby="image-gallery__open-gallery"
   {% endif %}
   >
   {{ title_suffix.contextual_links }}

--- a/templates/form-element-bare.html.twig
+++ b/templates/form-element-bare.html.twig
@@ -1,0 +1,55 @@
+{#
+/**
+ * @file
+ * Theme override for a form element.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - errors: (optional) Any errors for this form element, may not be set.
+ * - prefix: (optional) The form element prefix, may not be set.
+ * - suffix: (optional) The form element suffix, may not be set.
+ * - required: The required marker, or empty if the associated form element is
+ *   not required.
+ * - type: The type of the element.
+ * - name: The name of the element.
+ * - label: A rendered label element.
+ * - label_display: Label display setting. It can have these values:
+ *   - before: The label is output before the element. This is the default.
+ *     The label includes the #title and the required marker, if #required.
+ *   - after: The label is output after the element. For example, this is used
+ *     for radio and checkbox #type elements. If the #title is empty but the
+ *     field is #required, the label will contain only the required marker.
+ *   - invisible: Labels are critical for screen readers to enable them to
+ *     properly navigate through forms but can be visually distracting. This
+ *     property hides the label for everyone except screen readers.
+ *   - attribute: Set the title attribute on the element to create a tooltip but
+ *     output no label element. This is supported only for checkboxes and radios
+ *     in \Drupal\Core\Render\Element\CompositeFormElementTrait::preRenderCompositeFormElement().
+ *     It is used where a visual label is not needed, such as a table of
+ *     checkboxes where the row and column provide the context. The tooltip will
+ *     include the title and required marker.
+ * - description: (optional) A list of description properties containing:
+ *    - content: A description of the form element, may not be set.
+ *    - attributes: (optional) A list of HTML attributes to apply to the
+ *      description content wrapper. Will only be set when description is set.
+ * - description_display: Description display setting. It can have these values:
+ *   - before: The description is output before the element.
+ *   - after: The description is output after the element. This is the default
+ *     value.
+ *   - invisible: The description is output after the element, hidden visually
+ *     but available to screen readers.
+ * - disabled: True if the element is disabled.
+ * - title_display: Title display setting.
+ *
+ * @see template_preprocess_form_element()
+ */
+#}
+
+{{ label }}
+{{ children }}
+{% if errors %}
+  <div class="field-message error" role="alert">
+    {{ errors }}
+    <div class="accolade"></div>
+  </div>
+{% endif %}

--- a/translations/de.po
+++ b/translations/de.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2019-10-01 11:00+0200\n"
-"PO-Revision-Date: 2019-10-01 11:05+0200\n"
+"POT-Creation-Date: 2019-10-28 14:57+0100\n"
+"PO-Revision-Date: 2019-10-28 15:50+0100\n"
 "Last-Translator: Helena Standaert <helena.standaert@digipolis.gent>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -48,31 +48,31 @@ msgstr ""
 "wird verwendet, um das Favicon für Android + Windows-Smartphones und für "
 "Apple-Computer mit Touch Bar korrekt einzustellen."
 
-#: themes/contrib/gent_base/gent_base.theme:308;308
+#: themes/contrib/gent_base/gent_base.theme:316;316
 msgid "Search"
 msgstr "Suchen"
 
-#: themes/contrib/gent_base/gent_base.theme:446
+#: themes/contrib/gent_base/gent_base.theme:454
 msgid "programme"
 msgstr "Programm"
 
-#: themes/contrib/gent_base/gent_base.theme:451
+#: themes/contrib/gent_base/gent_base.theme:459
 msgid "timeline"
 msgstr "Zeitlinie"
 
-#: themes/contrib/gent_base/gent_base.theme:492
+#: themes/contrib/gent_base/gent_base.theme:500
 msgid "There is 1 other document"
 msgstr "Es gibt 1 anderes Dokument"
 
-#: themes/contrib/gent_base/gent_base.theme:495
+#: themes/contrib/gent_base/gent_base.theme:503
 msgid "There are @count other documents"
 msgstr "@count andere Dokumente sind verfügbar"
 
-#: themes/contrib/gent_base/gent_base.theme:1032
+#: themes/contrib/gent_base/gent_base.theme:1040
 msgid "@category - All"
 msgstr "@category - Alle"
 
-#: themes/contrib/gent_base/gent_base.theme:1072
+#: themes/contrib/gent_base/gent_base.theme:1079
 #: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:14
 msgid "View on the map"
 msgstr "Auf der Karte zeigen"
@@ -88,6 +88,15 @@ msgstr "Gent Base-Thema. Verwenden Sie immer ein Subthema dieses Themas."
 #: themes/contrib/gent_base/source/js/dg_maps.baselayerswitcher.js:0
 msgid "Legend"
 msgstr "Legende"
+
+#: themes/contrib/gent_base/source/js/dg_maps.datalayerswitcher.js:0
+#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:46
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48
+#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:28
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
+msgid "Close"
+msgstr "Schließen"
 
 #: themes/contrib/gent_base/source/js/file.bindings.js:0
 msgid "No file chosen."
@@ -139,14 +148,6 @@ msgstr "Karte"
 #: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:14
 msgid "List"
 msgstr "Liste"
-
-#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:46
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48
-#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:28
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
-msgid "Close"
-msgstr "Schließen"
 
 #: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:58
 msgid "Filter the list below"
@@ -252,7 +253,7 @@ msgid "Show all photos"
 msgstr "Alle Fotos ansehen"
 
 #: themes/contrib/gent_base/templates/core/form/fieldset.html.twig:47
-#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:31
+#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:30
 msgid "Optional"
 msgstr "Optional"
 

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -28,8 +28,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2019-10-01 11:00+0200\n"
-"PO-Revision-Date: 2019-10-01 11:05+0200\n"
+"POT-Creation-Date: 2019-10-28 14:57+0100\n"
+"PO-Revision-Date: 2019-10-28 15:49+0100\n"
 "Last-Translator: Helena Standaert <helena.standaert@digipolis.gent>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -75,31 +75,31 @@ msgstr ""
 "paramètre est utilisé pour configurer correctement le favicon pour les "
 "téléphones Android + Windows et pour les ordinateurs Apple avec Touch Bar."
 
-#: themes/contrib/gent_base/gent_base.theme:308;308
+#: themes/contrib/gent_base/gent_base.theme:316;316
 msgid "Search"
 msgstr "Rechercher"
 
-#: themes/contrib/gent_base/gent_base.theme:446
+#: themes/contrib/gent_base/gent_base.theme:454
 msgid "programme"
 msgstr "programme"
 
-#: themes/contrib/gent_base/gent_base.theme:451
+#: themes/contrib/gent_base/gent_base.theme:459
 msgid "timeline"
 msgstr "ligne du temps"
 
-#: themes/contrib/gent_base/gent_base.theme:492
+#: themes/contrib/gent_base/gent_base.theme:500
 msgid "There is 1 other document"
 msgstr "Il y a 1 autre document"
 
-#: themes/contrib/gent_base/gent_base.theme:495
+#: themes/contrib/gent_base/gent_base.theme:503
 msgid "There are @count other documents"
 msgstr "Il y a @count autres documents"
 
-#: themes/contrib/gent_base/gent_base.theme:1032
+#: themes/contrib/gent_base/gent_base.theme:1040
 msgid "@category - All"
 msgstr "@category - Tous"
 
-#: themes/contrib/gent_base/gent_base.theme:1072
+#: themes/contrib/gent_base/gent_base.theme:1079
 #: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:14
 msgid "View on the map"
 msgstr "Afficher sur la carte"
@@ -115,6 +115,15 @@ msgstr "Thème Gent base. Utilisez toujours un sous-thème de ce thème."
 #: themes/contrib/gent_base/source/js/dg_maps.baselayerswitcher.js:0
 msgid "Legend"
 msgstr "Légende"
+
+#: themes/contrib/gent_base/source/js/dg_maps.datalayerswitcher.js:0
+#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:46
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48
+#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:28
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
+msgid "Close"
+msgstr "Fermer"
 
 #: themes/contrib/gent_base/source/js/file.bindings.js:0
 msgid "No file chosen."
@@ -166,14 +175,6 @@ msgstr "Carte"
 msgid "List"
 msgstr "Liste"
 
-#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:46
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48
-#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:28
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
-msgid "Close"
-msgstr "Fermer"
-
 #: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:58
 msgid "Filter the list below"
 msgstr "Filtrer la liste ci-dessous"
@@ -203,7 +204,7 @@ msgstr "De %min à %max ans"
 msgid "There is 1 result"
 msgid_plural "There are @count results"
 msgstr[0] "Il y a 1 résultat"
-msgstr[1] ""
+msgstr[1] "Il y a @count résultats"
 
 #: themes/contrib/gent_base/templates/contrib/facets/facets-summary-item-list.html.twig:51
 msgid "You have selected"
@@ -278,7 +279,7 @@ msgid "Show all photos"
 msgstr "Consultez toutes les photos"
 
 #: themes/contrib/gent_base/templates/core/form/fieldset.html.twig:47
-#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:31
+#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:30
 msgid "Optional"
 msgstr "Facultatif"
 

--- a/translations/general.pot
+++ b/translations/general.pot
@@ -8,6 +8,12 @@
 #  themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig: n/a
 #  themes/contrib/gent_base/gent_base.info.yml: n/a
 #  themes/contrib/gent_base/source/js/dg_maps.baselayerswitcher.js: n/a
+#  themes/contrib/gent_base/source/js/dg_maps.datalayerswitcher.js: n/a
+#  themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig: n/a
+#  themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig: n/a
+#  themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig: n/a
+#  themes/contrib/gent_base/templates/core/layout/region--filters.html.twig: n/a
+#  themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig: n/a
 #  themes/contrib/gent_base/source/js/file.bindings.js: n/a
 #  themes/contrib/gent_base/source/js/table.bindings.js: n/a
 #  themes/contrib/gent_base/starterkit/starterkit.info.yml: n/a
@@ -15,11 +21,6 @@
 #  themes/contrib/gent_base/templates/core/form/form.html.twig: n/a
 #  themes/contrib/gent_base/templates/contrib/dg-auth/dg-auth-block.html.twig: n/a
 #  themes/contrib/gent_base/templates/contrib/dg_blocks/block--dg-blocks-gentinfo-block.html.twig: n/a
-#  themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig: n/a
-#  themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig: n/a
-#  themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig: n/a
-#  themes/contrib/gent_base/templates/core/layout/region--filters.html.twig: n/a
-#  themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig: n/a
 #  themes/contrib/gent_base/templates/contrib/facets/facets-item-list--range-slider.html.twig: n/a
 #  themes/contrib/gent_base/templates/contrib/facets/facets-summary-count.html.twig: n/a
 #  themes/contrib/gent_base/templates/contrib/facets/facets-summary-item-list.html.twig: n/a
@@ -54,7 +55,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2019-10-01 11:00+0200\n"
+"POT-Creation-Date: 2019-10-28 14:57+0100\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -87,31 +88,31 @@ msgstr ""
 msgid "Fill in the color scheme primary HEX color to be used in your project, leave empty for the default color scheme. This setting is only used for displaying the favicon correctly on Android + Windows phones and Apple's Touch Bar enabled computers."
 msgstr ""
 
-#: themes/contrib/gent_base/gent_base.theme:308;308
+#: themes/contrib/gent_base/gent_base.theme:316;316
 msgid "Search"
 msgstr ""
 
-#: themes/contrib/gent_base/gent_base.theme:446
+#: themes/contrib/gent_base/gent_base.theme:454
 msgid "programme"
 msgstr ""
 
-#: themes/contrib/gent_base/gent_base.theme:451
+#: themes/contrib/gent_base/gent_base.theme:459
 msgid "timeline"
 msgstr ""
 
-#: themes/contrib/gent_base/gent_base.theme:492
+#: themes/contrib/gent_base/gent_base.theme:500
 msgid "There is 1 other document"
 msgstr ""
 
-#: themes/contrib/gent_base/gent_base.theme:495
+#: themes/contrib/gent_base/gent_base.theme:503
 msgid "There are @count other documents"
 msgstr ""
 
-#: themes/contrib/gent_base/gent_base.theme:1032
+#: themes/contrib/gent_base/gent_base.theme:1040
 msgid "@category - All"
 msgstr ""
 
-#: themes/contrib/gent_base/gent_base.theme:1072 themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:14
+#: themes/contrib/gent_base/gent_base.theme:1079 themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:14
 msgid "View on the map"
 msgstr ""
 
@@ -125,6 +126,10 @@ msgstr ""
 
 #: themes/contrib/gent_base/source/js/dg_maps.baselayerswitcher.js:0
 msgid "Legend"
+msgstr ""
+
+#: themes/contrib/gent_base/source/js/dg_maps.datalayerswitcher.js:0 themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71 themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:46 themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48 themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:28 themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
+msgid "Close"
 msgstr ""
 
 #: themes/contrib/gent_base/source/js/file.bindings.js:0
@@ -173,10 +178,6 @@ msgstr ""
 
 #: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:14
 msgid "List"
-msgstr ""
-
-#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71 themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:46 themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48 themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:28 themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
-msgid "Close"
 msgstr ""
 
 #: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:58
@@ -273,7 +274,7 @@ msgstr ""
 msgid "Show all photos"
 msgstr ""
 
-#: themes/contrib/gent_base/templates/core/form/fieldset.html.twig:47 themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:31
+#: themes/contrib/gent_base/templates/core/form/fieldset.html.twig:47 themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:30
 msgid "Optional"
 msgstr ""
 

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -42,8 +42,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2019-10-01 11:00+0200\n"
-"PO-Revision-Date: 2019-10-01 11:04+0200\n"
+"POT-Creation-Date: 2019-10-28 14:57+0100\n"
+"PO-Revision-Date: 2019-10-28 15:48+0100\n"
 "Last-Translator: Helena Standaert <helena.standaert@digipolis.gent>\n"
 "Language-Team: Digipolis <tbweb@gent.be>\n"
 "Language: nl\n"
@@ -89,31 +89,31 @@ msgstr ""
 "favicon correct in te stellen voor Android + Windows telefoons en voor "
 "Apple's computers met Touch Bar."
 
-#: themes/contrib/gent_base/gent_base.theme:308;308
+#: themes/contrib/gent_base/gent_base.theme:316;316
 msgid "Search"
 msgstr "Zoeken"
 
-#: themes/contrib/gent_base/gent_base.theme:446
+#: themes/contrib/gent_base/gent_base.theme:454
 msgid "programme"
 msgstr "programma"
 
-#: themes/contrib/gent_base/gent_base.theme:451
+#: themes/contrib/gent_base/gent_base.theme:459
 msgid "timeline"
 msgstr "tijdslijn"
 
-#: themes/contrib/gent_base/gent_base.theme:492
+#: themes/contrib/gent_base/gent_base.theme:500
 msgid "There is 1 other document"
 msgstr "Er is 1 ander document"
 
-#: themes/contrib/gent_base/gent_base.theme:495
+#: themes/contrib/gent_base/gent_base.theme:503
 msgid "There are @count other documents"
 msgstr "Er zijn @count andere documenten"
 
-#: themes/contrib/gent_base/gent_base.theme:1032
+#: themes/contrib/gent_base/gent_base.theme:1040
 msgid "@category - All"
 msgstr "@category - Alle"
 
-#: themes/contrib/gent_base/gent_base.theme:1072
+#: themes/contrib/gent_base/gent_base.theme:1079
 #: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:14
 msgid "View on the map"
 msgstr "Toon op de kaart"
@@ -129,6 +129,15 @@ msgstr "Gent base theme. Gebruik altijd een subthema van dit thema."
 #: themes/contrib/gent_base/source/js/dg_maps.baselayerswitcher.js:0
 msgid "Legend"
 msgstr "Legende"
+
+#: themes/contrib/gent_base/source/js/dg_maps.datalayerswitcher.js:0
+#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:46
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48
+#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:28
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
+msgid "Close"
+msgstr "Sluiten"
 
 #: themes/contrib/gent_base/source/js/file.bindings.js:0
 msgid "No file chosen."
@@ -178,14 +187,6 @@ msgstr "Kaart"
 #: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:14
 msgid "List"
 msgstr "Lijst"
-
-#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:46
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48
-#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:28
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
-msgid "Close"
-msgstr "Sluiten"
 
 #: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:58
 msgid "Filter the list below"
@@ -291,7 +292,7 @@ msgid "Show all photos"
 msgstr "Bekijk alle foto's"
 
 #: themes/contrib/gent_base/templates/core/form/fieldset.html.twig:47
-#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:31
+#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:30
 msgid "Optional"
 msgstr "Optioneel"
 


### PR DESCRIPTION
### Added

* Partner paragraph.
* Theme wrapper "form_element_bare".
* ID attribute for map regions.
* Label to close button in map legend.
* Force `alt` attribute for images, even if it's empty.
* Template for local actions block.

### Updated

* Optimize aria attributes for image galleries.
* Added `role="alert"` to error messages.

### Fixed

* Missing label for dropdown facets.
* Broken focus outline for map controls.
* Modal layout for filters.
* Fixed typo in table-mobile script that caused JS error in Safari.