### PR TITLE
Added fix to show field descriptions in a message box.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
+## [Unreleased]
+
+### Fixed
+
+* Fixed field description styling for certain types of fields.
+
 ## [8.x-3.0-beta12]
 
 ### Fixed

--- a/source/sass/21-atoms/file/_file.scss
+++ b/source/sass/21-atoms/file/_file.scss
@@ -1,5 +1,11 @@
 .file {
+  min-width: 17rem;
+  margin: 0 -.3rem;
   padding-left: 0;
+
+  &::after {
+    display: none;
+  }
 }
 
 .form-managed-file {

--- a/templates/core/content-edit/image-widget.html.twig
+++ b/templates/core/content-edit/image-widget.html.twig
@@ -10,7 +10,7 @@
  * @see template_preprocess_image_widget()
  */
 #}
-<div{{ attributes }}>
+<div{{ attributes.addClass('file') }}>
   <div class="image-widget-data">
     {# Render widget data without the image preview that was output already. #}
     {{ data|without('preview') }}

--- a/templates/core/form/form-element.html.twig
+++ b/templates/core/form/form-element.html.twig
@@ -75,6 +75,7 @@
 {%
   set description_classes = [
     'form-description',
+    'field-message',
     description_display == 'invisible' ? 'visually-hidden',
   ]
 %}
@@ -107,6 +108,14 @@
       {% if prefix is not empty %}
         <span class="field-prefix">{{ prefix }}</span>
       {% endif %}
+
+      {% if description.content and type != 'managed_file' %}
+        <div{{ description.attributes.addClass(description_classes) }}>
+          {{ description.content }}
+          <div class="accolade"></div>
+        </div>
+      {% endif %}
+
       {{ children }}
       {% if suffix is not empty %}
         <span class="field-suffix">{{ suffix }}</span>
@@ -116,9 +125,11 @@
       {% endif %}
 
       {% if description.content %}
-        <div{{ description.attributes.addClass(description_classes) }}>
-          {{ description.content }}
-        </div>
+        {% if type == 'managed_file' %}
+          <div class="help-text">
+            {{ description.content }}
+          </div>
+        {% endif %}
       {% endif %}
 
       {% if information and label_display == 'after' %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Not all fields have their help text displayed in a field message (blue box with accolade). 
This PR fixes that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="593" alt="Screenshot 2019-11-25 at 15 31 01" src="https://user-images.githubusercontent.com/30627591/69548946-a2438100-0f98-11ea-821c-47a31f250b4d.png">
<img width="481" alt="Screenshot 2019-11-25 at 15 31 09" src="https://user-images.githubusercontent.com/30627591/69548954-a53e7180-0f98-11ea-9204-82e2971a2fcd.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
