### PR TITLE
DTGB-785: Changed menu.bindings.js file to use Modal instead of Menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
+## [Unreleased]
+
+### Fixed
+
+* Fixed menu.bindings.js file to work with the Modal instead of a Menu reference.
+
 ## [8.x-3.0-beta13]
 
 ### Added

--- a/source/js/menu.bindings.js
+++ b/source/js/menu.bindings.js
@@ -7,13 +7,33 @@
 
   Drupal.behaviors.gentBaseLoadMenu = {
     attach: function (context, settings) {
-      if (!Menu) { // eslint-disable-line no-undef
+      if (!Modal) { // eslint-disable-line no-undef
         return;
       }
 
-      var selected = document.querySelectorAll('nav.menu');
-      for (var i = selected.length; i--;) {
-        new Menu(selected[i]); // eslint-disable-line no-undef
+      var menu = document.querySelectorAll('.modal.menu');
+
+      var createModal = function (modal) {
+        // eslint-disable-next-line no-undef
+        new Modal(modal, {
+          // The modal is always visible from tablet and up,
+          // this is atypical.
+          resizeEvent: function (open, close) {
+            if (window.innerWidth > 960) {
+              close();
+              modal.setAttribute('aria-hidden', 'false');
+            }
+            else {
+              if (!modal.classList.contains('visible')) {
+                modal.setAttribute('aria-hidden', 'true');
+              }
+            }
+          }
+        });
+      };
+
+      for (var i = menu.length; i--;) {
+        createModal(menu[i]);
       }
     }
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This changes the menu.bindings.js file to use Modal instead of Menu to open and close a mobile menu.
**This can break existing websites that use menus!**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
