### PR TITLE
Removed form-tag from region, added it to the individual facets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
+## [Unreleased]
+
+### Updated
+
+* Removed form-tag from region-filters template and added a form-tag to the 
+facet templates. This may break custom facets that rely on the form-tag. 
+
 ## [8.x-3.0-beta14]
 
 ### Fixed

--- a/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig
+++ b/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig
@@ -30,7 +30,7 @@
 } %}
 
 {{ attach_library('gent_base/checkbox_filter') }}
-
+<form>
 <fieldset class="facets-widget- {{- facet.widget.type -}} -with-filter checkbox-filter form-item">
   {% if items or empty %}
     {%- if title is not empty -%}
@@ -120,3 +120,4 @@
     {%- endif -%}
   {%- endif %}
 </fieldset>
+</form>

--- a/templates/contrib/facets/facets-item-list--checkbox.html.twig
+++ b/templates/contrib/facets/facets-item-list--checkbox.html.twig
@@ -24,6 +24,7 @@
  * @ingroup themeable
  */
 #}
+<form>
 <fieldset class="form-item facets-widget- {{- facet.widget.type -}} ">
   {% if facet.widget.type %}
     {%- set attributes = attributes.addClass('item-list__' ~ facet.widget.type) %}
@@ -44,3 +45,4 @@
     {%- endif -%}
   {%- endif %}
 </fieldset>
+</form>

--- a/templates/contrib/facets/facets-item-list--dropdown.html.twig
+++ b/templates/contrib/facets/facets-item-list--dropdown.html.twig
@@ -24,6 +24,7 @@
  * @ingroup themeable
  */
 #}
+<form>
 <div class="form-item facets-widget- {{- facet.widget.type -}} ">
   {% if facet.widget.type %}
     {%- set attributes = attributes.addClass('item-list__' ~ facet.widget.type) %}
@@ -44,3 +45,4 @@
     {%- endif -%}
   {%- endif %}
 </div>
+</form>

--- a/templates/contrib/facets/facets-item-list--range-slider.html.twig
+++ b/templates/contrib/facets/facets-item-list--range-slider.html.twig
@@ -26,6 +26,7 @@
 #}
 {{ attach_library('gent_base/facet_range_slider') }}
 
+<form>
 <div class="form-item facets-widget- {{- facet.widget.type -}} ">
   {% if facet.widget.type %}
     {%- set attributes = attributes.addClass('item-list__' ~ facet.widget.type) %}
@@ -50,3 +51,4 @@
     {%- endif -%}
   {%- endif %}
 </div>
+</form>

--- a/templates/core/layout/region--filters.html.twig
+++ b/templates/core/layout/region--filters.html.twig
@@ -32,9 +32,7 @@
 
       <div class="modal-content">
         <h2>{{ 'Filter the results'|t }}</h2>
-        <form>
-          {{ content }}
-        </form>
+        {{ content }}
       </div>
       <div class="modal-actions">
         <button type="button" class="button button-primary modal-close filter-show-results-button" data-target="filter">{{ 'Show results'|t }}</button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Not all the content in de filter region needs a form-tag, some have their own. The form tag is necessary for the facets with checkboxes, dropdown & other form elements though. Moved them there.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
