### PR TITLE
Fixed issue for empty legend items for maps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed empty legend items for maps.
+
+## [8.x-3.0-beta15]
+
 ### Added
 
 * Added fix for fieldsets and datetime wrappers.

--- a/source/js/dg_maps.datalayerswitcher.js
+++ b/source/js/dg_maps.datalayerswitcher.js
@@ -125,7 +125,13 @@
         var legendContainer = document.createElement('div');
         legendContainer.className = 'legend';
 
+
         for (var j = 0; j < legendData.length; j++) {
+          // Remove empty items from the data layer switcher list.
+          if (!legendData[j].label) {
+            continue;
+          }
+
           var legendItemContainer = document.createElement('div');
           legendItemContainer.className = 'legend__item';
           legendContainer.appendChild(legendItemContainer);
@@ -138,7 +144,7 @@
 
           var legendItemLabel = document.createElement('span');
           legendItemIcon.className = 'legend__item__label';
-          legendItemLabel.innerHTML = legendData[j].label ? legendData[j].label : '';
+          legendItemLabel.innerHTML = legendData[j].label;
           legendItemContainer.appendChild(legendItemLabel);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A bug where empty tags where showed in the map legend is fixed here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="450" alt="Screenshot 2020-01-20 at 11 26 30" src="https://user-images.githubusercontent.com/30627591/72719234-bca07200-3b77-11ea-80c3-6d39ad1f249f.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
