### PR TITLE
DTGB-805: Fixed fieldset (fieldgroup) wrongly marked as "optional"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed fieldset (fieldgroup) wrongly marked as "optional".
+
 ### Removed
 
 * Removed unsupported pubdate attribute in time tag.

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     ]
   },
   "require": {
+    "php": ">=7.2",
     "drupal/coder": "^8.2"
   }
 }

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -412,9 +412,10 @@ function gent_base_preprocess_fieldset(&$variables) {
     $element['#information'] = $element['#description'];
   }
 
-  if ($element['#type'] === 'fieldset' && empty($element['#required'])) {
-    $variables['fieldset_optional'] = TRUE;
-  }
+  // Fieldsets themselves should not be marked as optional.
+  // Only a fieldset wrapping Radios & Checkboxes should be marked as such.
+  $variables['fieldset_optional'] = $element['#type'] !== 'fieldset'
+    && empty($element['#required']);
 
   if (isset($element['#has_row'])) {
     $variables['has_row'] = $element['#has_row'] ?? NULL;
@@ -436,7 +437,6 @@ function gent_base_preprocess_menu_local_task(&$variables) {
   else {
     $variables['link']['#options']['attributes']['class'][] = 'button-secondary';
   }
-
 }
 
 /**

--- a/templates/core/form/fieldset.html.twig
+++ b/templates/core/form/fieldset.html.twig
@@ -19,6 +19,11 @@
  * - prefix: The content to add before the fieldset children.
  * - suffix: The content to add after the fieldset children.
  *
+ * Extra variables:
+ * - fieldset_optional: Should the fieldset be marked as optional.
+ * - has_row: Should the fieldset be rendered as a row.
+ * - has_columns: Has the fieldset columns.
+ *
  * @see template_preprocess_fieldset()
  */
 #}
@@ -45,7 +50,7 @@
   <legend{{ legend.attributes.addClass(legend_span_classes) }}>
     {{ legend.title }}
 
-    {% if not required %}
+    {% if fieldset_optional %}
       <span{{ legend_span.attributes.addClass('label-optional') }}>({{ 'Optional'|t }})</span>
     {% endif %}
   </legend>


### PR DESCRIPTION
Fieldsets added by the field_group module are wrongly being marked as `(optional)`.

## Description

A fieldset should only be marked as "(optional)" when:

* The fieldset element is not "fieldset" (radios, checkboxes).
* The fieldset element is marked as required.

## Motivation and Context

* Correct indication of optional fieldsets.
* Avoid double optional indications for the same elements.

## How Has This Been Tested?

User tests.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
