### PR TITLE
DTGB-830: Added temp fix for bug in styleguide.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,25 +22,23 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 ### Fixed
 
 * Modal fixed-height had a scrollable region without keyboard access.
-The template has been updated, make sure to add tabindex=0 on all your 
-.modal--fixed-height templates in your project too.
-
+  The template has been updated, make sure to add tabindex=0 on all your
+  .modal--fixed-height templates in your project too.
 * Fixed notice: Undefined index:
   '#items' in `gent_base_preprocess_paragraph__image()`.
 
 ### Changed
 
-* Deprecated: ‘mijn-gent-block’ has been renamed to the more generic 
-‘authentication’ in order to match the documentation.
-The ‘.mijn-gent-block’ class is still functional but marked as deprecated.
-Please use ‘.authentication’ from now on.
-
+* Deprecated: ‘mijn-gent-block’ has been renamed to the more generic
+  ‘authentication’ in order to match the documentation.
+  The ‘.mijn-gent-block’ class is still functional but marked as deprecated.
+  Please use ‘.authentication’ from now on.
 * Replaced box by highlight.
 
 ### Removed
 
-* Deprecated modal.functions.js has been replaced by modal/index.js 
-from @digipolis-gent/modal as npm dependency.
+* Deprecated modal.functions.js has been replaced by modal/index.js
+  from @digipolis-gent/modal as npm dependency.
 
 ## [8.x-3.0-beta17]
 

--- a/source/sass/31-molecules/contact-details/_contact-details.scss
+++ b/source/sass/31-molecules/contact-details/_contact-details.scss
@@ -1,0 +1,11 @@
+/// Temporary fix - @TODO Remove when we use styleguide 3.0.1.
+//  Fixed in latest unreleased branch 3.x-dev of sg styleguide.
+
+.contact-details-inverted {
+  .accolade {
+    &::before,
+    &::after {
+      @include theme('background', 'color-secondary', 'contact-details-inverted-background-color');
+    }
+  }
+}


### PR DESCRIPTION
## Description
Fixed bug in styleguide with accolade component in contact-details-inverted context.
Added some temporary styling in a new contact-details molecule.

## Motivation and Context
Accolades of form error messages have wrong background color in context of a contact-details-inverted component.

## How Has This Been Tested?
In kot@gent op een pand detailpagina staat een formulier in het contact-details-inverted block. Hierdoor krijgen de accolades van de form messages een verkeerde achtergrondkleur. Extra css voorzien.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
