### PR TITLE
DTGB-820: Fixed classname in template para cta.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
+## [Unreleased]
+
+### Fixed
+
+* DTGB-820: Updated deprecated classname inner-highlight to hightlight__inner.
+
 ## [3.0-beta20]
 
 ### Fixed

--- a/templates/contrib/paragraphs/cta/paragraph--call-to-action.html.twig
+++ b/templates/contrib/paragraphs/cta/paragraph--call-to-action.html.twig
@@ -52,7 +52,7 @@
 
 {% block paragraph %}
   <div{{ attributes.addClass(classes).addClass(custom_classes) }}>
-    <div class="inner-highlight">
+    <div class="highlight__inner">
       <div>
       {% block content %}
         {{ content|without(


### PR DESCRIPTION
## Description
Update template paragraph--call-to-action.html_twig

## Motivation and Context
Class inner-highlight is deprecated. DTGB-820

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
