### PR TITLE
DTGB-874: Added field-message class to prefix fieldsets.

### DIFF
--- a/templates/core/form/fieldset.html.twig
+++ b/templates/core/form/fieldset.html.twig
@@ -85,12 +85,14 @@
         </div>
         {% endif %}
 
-        {% if has_columns and errors %}
+        {% if has_columns %}
         <div class="form-item-column">
+          {% if errors %}
           <div class="field-message error" role="alert">
             {{ errors }}
             <div class="accolade"></div>
           </div>
+          {% endif %}
         </div>
       </div>
       {% if suffix %}

--- a/templates/core/form/fieldset.html.twig
+++ b/templates/core/form/fieldset.html.twig
@@ -71,30 +71,31 @@
 
     {% if has_columns %}
     <div class="form-item">
+      {% if prefix %}
+        <div class="field-message">
+          {{ prefix }}
+          <div class="accolade"></div>
+        </div>
+      {% endif %}
       <div class="form-columns">
         <div class="form-item-column">
           {% endif %}
-          {% if prefix %}
-            <span class="field-prefix">{{ prefix }}</span>
-          {% endif %}
           {{ children }}
-          {% if suffix %}
-            <span class="field-suffix">{{ suffix }}</span>
-          {% endif %}
           {% if has_columns %}
         </div>
         {% endif %}
 
-        {% if has_columns %}
+        {% if has_columns and errors %}
         <div class="form-item-column">
-          {% if errors %}
-            <div class="field-message error" role="alert">
-              {{ errors }}
-              <div class="accolade"></div>
-            </div>
-          {% endif %}
+          <div class="field-message error" role="alert">
+            {{ errors }}
+            <div class="accolade"></div>
+          </div>
         </div>
       </div>
+      {% if suffix %}
+        <span class="field-suffix">{{ suffix }}</span>
+      {% endif %}
     </div>
     {% endif %}
     {% if has_row %}


### PR DESCRIPTION
Webforms use prefix variable to add description, which is themed as field-message in styleguide.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
