### PR TITLE
DTGB-867: Fix faulty twig array slice

### DIFF
--- a/templates/contrib/facets/facets-item-list--checkbox.html.twig
+++ b/templates/contrib/facets/facets-item-list--checkbox.html.twig
@@ -133,7 +133,7 @@
               <div class="checkbox-accordion">
                 <div class="accordion--content" aria-hidden="true" hidden="hidden" id="hidden-options-more-than-6-">
                   <div{{ attributes.addClass('links checkbox-filter__checkboxes') }}>
-                    {%- for item in items|slice(4, 6) -%}
+                    {%- for item in items|slice(3, 6) -%}
                     {# Multi-level filters #}
 
                     {% if (item.value.children) %}

--- a/templates/contrib/facets/facets-item-list--checkbox.html.twig
+++ b/templates/contrib/facets/facets-item-list--checkbox.html.twig
@@ -133,7 +133,7 @@
               <div class="checkbox-accordion">
                 <div class="accordion--content" aria-hidden="true" hidden="hidden" id="hidden-options-more-than-6-">
                   <div{{ attributes.addClass('links checkbox-filter__checkboxes') }}>
-                    {%- for item in items|slice(3, 6) -%}
+                    {%- for item in items|slice(3, 19) -%}
                     {# Multi-level filters #}
 
                     {% if (item.value.children) %}


### PR DESCRIPTION
Fix a missing facet option when "Show more" is being used cause by a faulty array slice in twig.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
