### PR TITLE
DTGB-871: Fix GrumpPHP error when installing in project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
+## [Unreleased]
+
+### Fixed
+
+* DTGB-871: Fix GrumpPHP error when installing in project.
+
 ## [4.4.0]
 
 ### Updated

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,7 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "bash -c 'cd ./scripts; ./install.sh;'",
-            "vendor/bin/grumphp git:init"
+            "bash -c 'cd ./scripts; ./install.sh;'"
         ],
         "post-update-cmd": [
             "bash -c 'cd ./scripts; ./install.sh;'"


### PR DESCRIPTION
## Description

There is an error reported during the installation of the base theme:

```
vendor/bin/grumphp git:init
sh: vendor/bin/grumphp: No such file or directory
Script vendor/bin/grumphp git:init handling the post-install-cmd event returned with error code 127
Script @composer --working-dir=web/themes/contrib/gent_base install --no-dev handling the post-install-cmd event returned with error code 127
```

The error is caused by the install scripts that triggers an composer install in the base theme directory.

The post-install scripts in the composer.json file want to init GrumPHP but it is not available since dev packages are not installed.

This post install step is not necessary when installing the Base theme for development; GrumPHP inits itself the moment it is installed.

See https://github.com/phpro/grumphp/blob/master/README.md:

> When the package is installed, GrumPHP will attach itself to the git hooks of your project. You will see following message in the composer logs:
>
> Watch out! GrumPHP is sniffing your commits!

## Motivation and Context

Fix error during install process.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
