### PR TITLE
DTBG-866: Fix double description on select other to 4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All Notable changes to `digipolisgent/drupal_theme_gent-base`.
 
 ### Fix
 
+* DTBG-866: Fix double description on select other
 * DTGB-857: Add fieldset legend attributes
 
 ### Added 

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -373,6 +373,7 @@ function gent_base_preprocess_fieldset(&$variables) {
   }
 
   $variables['has_columns'] = $element['#has_columns'] ?? NULL;
+  $variables['prefix'] = $element['#field_prefix'] ?? NULL;
 }
 
 /**

--- a/templates/core/form/fieldset.html.twig
+++ b/templates/core/form/fieldset.html.twig
@@ -53,13 +53,6 @@
   <div class="form-row">
     {% endif %}
 
-    {% if information %}
-      <div class="field-message">
-        {{ information.content }}
-        <div class="accolade"></div>
-      </div>
-    {% endif %}
-
     {% if errors and not has_columns %}
       <div class="field-message error" role="alert">
         {{ errors }}
@@ -69,11 +62,14 @@
 
     {% if has_columns %}
     <div class="form-item">
-      {% if prefix %}
-        <div class="field-message">
-          {{ prefix }}
+      {% if information %}
+        <div{{ information.attributes.addClass(information_classes) }}>
+          {{ information.content }}
           <div class="accolade"></div>
         </div>
+      {% endif %}
+      {% if prefix %}
+        <span class="field-prefix">{{ prefix }}</span>
       {% endif %}
       <div class="form-columns">
         <div class="form-item-column">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
