### PR TITLE
DTGB-881: Fix unwanted space between last word and period

### DIFF
--- a/templates/contrib/facets/facets-summary-count.html.twig
+++ b/templates/contrib/facets/facets-summary-count.html.twig
@@ -8,6 +8,5 @@
  */
 #}
 <h2 class="source-summary-count">
-  {% trans %}There is 1 result{% plural count %}There are {{ count }} results{% endtrans %}
-  .
+  {% trans %}There is 1 result{% plural count %}There are {{ count }} results{% endtrans %}.
 </h2>


### PR DESCRIPTION
The facets count summary has an unwanted space between the last word and the period.

## Description

The template (`templates/contrib/facets/facets-summary-count.html.twig`) has the period on a new line:

```twig
<h2 class="source-summary-count">
  {% trans %}There is 1 result{% plural count %}There are {{ count }} results{% endtrans %}
  .
</h2>
```

This results in an unwanted space between the last word and the period:

<img width="767" alt="DTGB-count-summary" src="https://user-images.githubusercontent.com/133124/201855100-50ee5fb1-9d33-4ea0-be3c-89d93f41050f.png">

## Solution

Moved the period on the same line as the translated string:

```twig
<h2 class="source-summary-count">
  {% trans %}There is 1 result{% plural count %}There are {{ count }} results{% endtrans %}.
</h2>
```