### PR TITLE
DTGB-893: Fix broken multiple image upload widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All Notable changes to `StadGent/drupal_theme_gent-base`.
 
 See Github releases for more information.
 
+### Fixed
+
+- DTGB-893: Fix broken multiple image upload widget.
+
 ## [4.4.0]
 
 ### Updated

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -659,11 +659,9 @@ function gent_base_preprocess_file_widget_multiple(array &$variables) {
       show($operations_elements[1]);
     }
 
-    /** @var \Drupal\Core\Render\RendererInterface $renderer */
-    $renderer = \Drupal::service('renderer');
     $row = [
       '#theme' => 'gent_base_file_upload',
-      '#picture_element' => $renderer->render($widget),
+      '#picture_element' => $widget,
       '#picture_button' => $operations_elements,
     ];
 


### PR DESCRIPTION
Multiple file upload widget is broken since Drupal 9.5.

- Previews are not shown.
- All images are deleted when one is removed.
- No images shown or saved after uploading.

## Description

The preprocess used the renderer to render the output. That is wrong, always use render arrays and let the theming layer do its work (other preprocessors need to do their work to).

## Motivation and Context

Give me back a working multiple-file/image upload.

## How Has This Been Tested?

- Tested in new Sport website.
- Drupal 9.5.3

## Screenshots (if appropriate):

<img width="840" alt="DTGB-file-upload-broken" src="https://user-images.githubusercontent.com/133124/223732678-cf1af237-5588-40dc-a708-4471f9214226.png">

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
