### PR TITLE
SGD8-2468: Remove specific coding for Filter Tags

### DIFF
--- a/source/sass/41-organisms/filter/_filter.scss
+++ b/source/sass/41-organisms/filter/_filter.scss
@@ -5,23 +5,6 @@
   }
 }
 
-.selected-filters {
-  .tag-list > li > a {
-    @include theme('color', 'color-tertiary', 'selected-filters-link-color');
-
-    font-weight: normal;
-    text-decoration: none;
-
-    &:hover {
-      background: none;
-    }
-
-    &[rel=nofollow] {
-      @include reset-link-background;
-    }
-  }
-}
-
 .result__show-filters.modal-trigger {
   display:  none;
 


### PR DESCRIPTION
## Description
- Removed the coding for filter tags from specific filters styling because they look the same as normal Filter Tags (so should be styled in Fractal)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
