### PR TITLE
SGD8-2687: Remove spotlight figcaption visually

### DIFF
--- a/source/sass/11-base/mixins/_mixins.scss
+++ b/source/sass/11-base/mixins/_mixins.scss
@@ -1,0 +1,8 @@
+@mixin visually-hidden {
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+  word-wrap: normal;
+}

--- a/source/sass/31-molecules/spotlight/_spotlight.scss
+++ b/source/sass/31-molecules/spotlight/_spotlight.scss
@@ -1,0 +1,7 @@
+//TODO: Figcaption on images in spotlight should be show (redesign needed)
+.paragraph--type--spotlight,
+.spotlight {
+  figcaption {
+    @include visually-hidden;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Hide the figcaption visually
- Added visually-hidden mixin to Gent Base theme
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
