### PR TITLE
HEAT-6670607: Update cache key if viewmode changes

### DIFF
--- a/gent_base.theme
+++ b/gent_base.theme
@@ -606,6 +606,10 @@ function gent_base_preprocess_field__field_contacts(&$variables) {
     }
     $variables['items'][$key]['content']['#view_mode'] = $view_mode;
     $variables['items'][$key]['content']['#cache']['tags'] = $entity->getCacheTags();
+    $cache_key = array_search('teaser', $variables['items'][$key]['content']['#cache']['keys']);
+    if ($cache_key !== FALSE) {
+      $variables['items'][$key]['content']['#cache']['keys'][$cache_key] = $view_mode;
+    }
   }
 }
 


### PR DESCRIPTION
We had a bug where sometimes teaser views on the openinghours overview pages (like /nl/openingsuren-adressen/trefwoord/dienst-wegen) would display as `teaser_with_link` and not as `teaser` view mode. After a lot of debugging the cause turned out to be that we _do_ update the cache tags in the preprocess hook, but not the cache keys. So the render cache would store the result of a `teaser_with_link` view mode as a `teaser` view mode and would return that for the overview page.