### PR TITLE
DTGB-902: Fix missing twig_typography module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All Notable changes to `StadGent/drupal_theme_gent-base`.
 ### Fixed
 
 - DTGB-901: Fix fatal error due to non existing field.
+- DTGB-902: Fix missing twig_typography module.
 
 ## [5.x]
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     ],
     "homepage": "https://bitbucket.org/digipolisgent/drupal_theme_gent-base",
     "require": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "drupal/twig_typography": "^2.1"
     },
     "require-dev": {
         "digipolisgent/qa-drupal": "^1.6",


### PR DESCRIPTION
Twig typography is used in templates but is not included as requirement. This results in fatal error.

## Motivation and Context

Twig typography was used to fix wrong-splitted (or not splitted) long words in titles. But it was not included as requirement for the base theme. This results in a fatal error.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
