### PR TITLE
DTGB-903: Add proper ID & class to content region when it contains filter results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All Notable changes to `StadGent/drupal_theme_gent-base`.
 
 ## [6.x]
 
+### Added
+
+- DTGB-903: Add proper ID and class to content region when on overview page
+  with filters.
+
 ### Fixed
 
 - DTGB-901: Fix fatal error due to non existing field.

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -9,6 +9,7 @@ use Drupal\block\Entity\Block;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Template\Attribute;
@@ -451,7 +452,6 @@ function gent_base_preprocess_field(&$variables) {
   if ($variables["element"]["#field_name"] == 'field_paragraphs') {
     $paragraphs = $variables['element']["#items"]->getIterator();
 
-    $isProgram = FALSE;
     $firstTimeline = FALSE;
     $timelineItemTotal = 0;
     $timelineOdd = FALSE;
@@ -486,13 +486,13 @@ function gent_base_preprocess_field(&$variables) {
             $firstTimeline = TRUE;
             $variables['items'][$key]['content']['first_timeframe'][0] = TRUE;
           }
-          if (count($paragraphs) === $key+1) {
+          if (count($paragraphs) === $key + 1) {
             $variables['items'][$key]['content']['last_timeframe'][0] = TRUE;
           }
         }
         elseif ($firstTimeline === TRUE) {
           $firstTimeline = FALSE;
-          $variables['items'][$key-1]['content']['last_timeframe'][0] = TRUE;
+          $variables['items'][$key - 1]['content']['last_timeframe'][0] = TRUE;
         }
       }
     }
@@ -800,7 +800,7 @@ function gent_base_preprocess_node(array &$variables): void {
   // Set datetime attributes on "Submitted on" label.
   $variables['author_attributes']
     ->setAttribute('datetime', \Drupal::service('date.formatter')
-    ->format($variables['date'], 'custom', 'c'));
+      ->format($variables['date'], 'custom', 'c'));
   $variables['author_attributes']
     ->setAttribute('pubdate', 'pubdate');
 

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -105,6 +105,7 @@ function gent_base_preprocess_page(&$variables) {
   $route = \Drupal::request()->get('_route');
   if ($route !== 'entity.node.canonical') {
     $variables['attributes']['class'][] = 'overview-page';
+    _gent_base_preprocess_page_content_region($variables);
     return;
   }
 
@@ -1517,6 +1518,21 @@ function gent_base_preprocess_file_upload_help(&$variables) {
   }
 
   $variables['descriptions'] = implode(' ', $descriptions);
+}
+
+/**
+ * Add result ID and class to content region when filters region is not empty.
+ *
+ * @param array $variables
+ *   The page variables.
+ */
+function _gent_base_preprocess_page_content_region(array &$variables): void {
+  if (empty($variables['page']['filters'])) {
+    return;
+  }
+
+  $variables['page']['content']['#attributes']['id'] = 'result';
+  $variables['page']['content']['#attributes']['class'][] = 'result-section';
 }
 
 /**

--- a/templates/core/layout/region--content.html.twig
+++ b/templates/core/layout/region--content.html.twig
@@ -14,7 +14,6 @@
 #}
 {% set classes = [
   'content',
-  'result-section',
 ] %}
 {% if content %}
   <section{{ attributes.addClass(classes) }}>


### PR DESCRIPTION
## Description

The Gent Style Guide defines a "result" ID on the section containing the filtered items overview. This is missing from the content section.

## Motivation and Context

- The ID is needed so we can point the browser direct to the proper section when a filter is added or removed.
- The class "result-section" should only be added to the content region when it contains filtered overview.

## How Has This Been Tested?

Added and tested on the Program overview of the Gentsefeesten website.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
