### PR TITLE
DTGB-905: Fix filters heading size and missing help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All Notable changes to `StadGent/drupal_theme_gent-base`.
 
 - DTGB-901: Fix fatal error due to non existing field.
 - DTGB-904: Fix gap in filter modal (fixed in Styleguide).
+- DTGB-905: Fix filters heading size and missing help text.
 - Remove word-break on language switcher links.
 
 ## [5.x]

--- a/templates/core/layout/region--filters.html.twig
+++ b/templates/core/layout/region--filters.html.twig
@@ -31,7 +31,8 @@
       </div>
 
       <div class="modal-content" tabindex="0">
-        <h2>{{ 'Filter the results'|t }}</h2>
+        <h3>{{ 'Filter the results'|t }}</h3>
+        <p class="help-text">{{ 'When selecting or deselecting filters, the page is automatically reloaded.'|t }}</p>
         {{ content }}
       </div>
       <div class="modal-actions">

--- a/translations/de.po
+++ b/translations/de.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-06-28 10:34+0200\n"
-"PO-Revision-Date: 2023-06-28 12:01+0200\n"
-"Last-Translator: Sven Vandevenne <sven.vandevenne@district09.gent>\n"
+"POT-Creation-Date: 2024-03-20 14:22+0100\n"
+"PO-Revision-Date: 2024-03-20 14:25+0100\n"
+"Last-Translator: Peter Decuyper <peter.decuyper@district09.gent>\n"
 "Language-Team: \n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: themes/contrib/gent_base/theme-settings.php:21
 msgid "Gent Base settings"
@@ -48,48 +48,40 @@ msgstr ""
 "wird verwendet, um das Favicon für Android + Windows-Smartphones und für "
 "Apple-Computer mit Touch Bar korrekt einzustellen."
 
-#: themes/contrib/gent_base/gent_base.theme:288;288
+#: themes/contrib/gent_base/gent_base.theme:319;319;317
 msgid "Search"
 msgstr "Suchen"
 
-#: themes/contrib/gent_base/gent_base.theme:430
-msgid "programme"
-msgstr "Programm"
-
-#: themes/contrib/gent_base/gent_base.theme:435
-msgid "timeline"
-msgstr "Zeitlinie"
-
-#: themes/contrib/gent_base/gent_base.theme:519
+#: themes/contrib/gent_base/gent_base.theme:566
 msgid "There is 1 other document"
 msgstr "Es gibt 1 anderes Dokument"
 
-#: themes/contrib/gent_base/gent_base.theme:522
+#: themes/contrib/gent_base/gent_base.theme:569
 msgid "There are @count other documents"
 msgstr "@count andere Dokumente sind verfügbar"
 
-#: themes/contrib/gent_base/gent_base.theme:686
+#: themes/contrib/gent_base/gent_base.theme:737
 msgid "Add new files"
 msgstr "Neue Dateien hinzufügen"
 
-#: themes/contrib/gent_base/gent_base.theme:1187
+#: themes/contrib/gent_base/gent_base.theme:1388
 msgid "@category - All"
 msgstr "@category - Alle"
 
-#: themes/contrib/gent_base/gent_base.theme:1238
-#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:14
+#: themes/contrib/gent_base/gent_base.theme:1442
+#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:16
 msgid "View on the map"
 msgstr "Auf der Karte zeigen"
 
-#: themes/contrib/gent_base/gent_base.theme:1303
+#: themes/contrib/gent_base/gent_base.theme:1507
 msgid "Allowed types: @extensions."
 msgstr "Zulässige Dateitypen: @extensions."
 
-#: themes/contrib/gent_base/gent_base.theme:1306
+#: themes/contrib/gent_base/gent_base.theme:1510
 msgid "Max filesize: @size."
 msgstr "Maximale Dateigröße: @size."
 
-#: themes/contrib/gent_base/gent_base.theme:1312
+#: themes/contrib/gent_base/gent_base.theme:1516
 msgid "Images must be larger than @min pixels."
 msgstr "Bilder müssen größer als @min Pixel sein."
 
@@ -101,16 +93,52 @@ msgstr "Gent Base"
 msgid "Ghent base theme. Always use a subtheme of this theme."
 msgstr "Gent Base-Thema. Verwenden Sie immer ein Subthema dieses Themas."
 
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Administration header"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Header top"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Header bottom"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+#, fuzzy
+#| msgid "Contacts"
+msgid "Content"
+msgstr "Kontakte"
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/templates/contrib/facets/facets-summary-item-list.html.twig:70
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:102
+msgid "Filters"
+msgstr "Filter"
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Footer"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+msgid "Mobile menu"
+msgstr ""
+
 #: themes/contrib/gent_base/source/js/dg_maps.baselayerswitcher.js:0
 msgid "Legend"
 msgstr "Legende"
 
 #: themes/contrib/gent_base/source/js/dg_maps.datalayerswitcher.js:0
-#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:48
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:178
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48
-#: themes/contrib/gent_base/templates/core/layout/page.html.twig:129
+#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:74
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:55
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--program.html.twig:49
+#: themes/contrib/gent_base/templates/core/layout/page.html.twig:121
 #: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:29
 #: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
 msgid "Close"
@@ -121,16 +149,8 @@ msgid "No file chosen."
 msgstr "Keine Datei."
 
 #: themes/contrib/gent_base/source/js/file.bindings.js:0
-msgid "No file chosen"
-msgstr "Keine Datei"
-
-#: themes/contrib/gent_base/source/js/file.bindings.js:0
 msgid "Multiple files."
 msgstr "Mehrere Dateien."
-
-#: themes/contrib/gent_base/source/js/file.bindings.js:0
-msgid "Multiple files"
-msgstr "Mehrere Dateien"
 
 #: themes/contrib/gent_base/source/js/table.bindings.js:0
 msgid "(Scroll to see more)"
@@ -148,22 +168,14 @@ msgstr "Beispiel eines Subthemas auf der Grundlage von Gent Base."
 msgid "Gent"
 msgstr "Gent"
 
-#: themes/contrib/gent_base/templates/gent-base-webform.html.twig:18
-#: themes/contrib/gent_base/templates/core/form/form.html.twig:15
+#: themes/contrib/gent_base/templates/gent-base-webform.html.twig:16
+#: themes/contrib/gent_base/templates/core/form/form.html.twig:16
 msgid "Fill in all fields unless otherwise stated."
 msgstr ""
 "Alle Felder sind Pflichtfelder, wenn sie nicht als optional gekennzeichnet "
 "sind."
 
-#: themes/contrib/gent_base/templates/contrib/dg-auth/dg-auth-block.html.twig:37
-msgid "Mijn Gent"
-msgstr "Mein Gent"
-
-#: themes/contrib/gent_base/templates/contrib/dg-auth/dg-auth-block.html.twig:44
-msgid "Show profile"
-msgstr "Profil öffnen"
-
-#: themes/contrib/gent_base/templates/contrib/dg_blocks/block--dg-blocks-gentinfo-block.html.twig:47
+#: themes/contrib/gent_base/templates/contrib/dg_blocks/block--dg-blocks-gentinfo-block.html.twig:46
 msgid "Chat with Gentinfo"
 msgstr "Chat mit Gentinfo"
 
@@ -175,43 +187,34 @@ msgstr "Karte"
 msgid "List"
 msgstr "Liste"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:60
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:189
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:68
 msgid "Filter the list below"
 msgstr "Folgende Liste filtern"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:65
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:198
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:77
 msgid "%count filter(s) found"
 msgstr "%count Filter gefunden"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:98;98
-#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:38
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:113
+#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:41
 msgid "Show results"
 msgstr "Ergebnisse zeigen"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:107
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:251
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:123
 msgid "%count item(s) selected"
 msgstr "%count Item(s) ausgewählt"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:112
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:130
 msgid "Select ..."
 msgstr "Auswählen..."
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:164;245
-msgid "Show more"
-msgstr "Zeig mehr"
-
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:233
-msgid "Confirm selection"
-msgstr "Auswahl bestätigen"
-
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--range-slider.html.twig:42
-msgid "From %min to %max year"
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--range-slider.html.twig:43
+#, fuzzy
+#| msgid "From %min to %max year"
+msgid "From %min to %max"
 msgstr "Von %min bis %max Jahren"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-result-item--summary.html.twig:24
+#: themes/contrib/gent_base/templates/contrib/facets/facets-result-item--summary.html.twig:25
 msgid "Remove this filter"
 msgstr "Entfernen Sie diesen Filter"
 
@@ -225,42 +228,66 @@ msgstr[1] "Es gibt @count Ergebnisse"
 msgid "You have selected"
 msgstr "Sie filterten nach"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-summary-item-list.html.twig:67
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:99
-msgid "Filters"
-msgstr "Filter"
-
-#: themes/contrib/gent_base/templates/contrib/opening_hours/opening-hours-widget.html.twig:45
+#: themes/contrib/gent_base/templates/contrib/opening_hours/opening-hours-widget.html.twig:47
 msgid "All opening hours"
 msgstr "Alle Öffnungszeiten"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/contact/paragraph--contact.html.twig:70
+#: themes/contrib/gent_base/templates/contrib/paragraphs/paragraph--contact.html.twig:70
 msgid "Call @phone"
 msgstr "Rufen Sie @phone an"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/contact/paragraph--contact.html.twig:80
-msgid "Send an email to @emailAddress"
+#: themes/contrib/gent_base/templates/contrib/paragraphs/paragraph--contact.html.twig:80
+#, fuzzy
+#| msgid "Send an email to @emailAddress"
+msgid "Send an email to @email_address"
 msgstr "Schicken Sie eine E-Mail an @emailAddress"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/contact/paragraph--contact.html.twig:87
+#: themes/contrib/gent_base/templates/contrib/paragraphs/paragraph--contact.html.twig:87
 msgid "View all contact info"
 msgstr "Alle Kontaktangaben"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:82
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-frame--program.html.twig:51
+msgid "programme"
+msgstr "Programm"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-frame--timeline.html.twig:51
+msgid "timeline"
+msgstr "Zeitlinie"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--program.html.twig:84
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:97
 msgid "More info"
 msgstr "Mehr erfahren"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:84
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--program.html.twig:86
 msgid "about"
 msgstr ""
 
-#: themes/contrib/gent_base/templates/contrib/webform/webform-progress-tracker.html.twig:27
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:48
+#, fuzzy
+#| msgid "More info"
+msgid "Important info"
+msgstr "Mehr erfahren"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:53
+msgid "Payment info"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:57
+msgid "Time-bound info"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:61
+msgid "Not to be missed info"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/contrib/webform/webform-progress-tracker.html.twig:28
 msgid "Steps in this wizard"
 msgstr "Schritte in diesem Formular"
 
-#: themes/contrib/gent_base/templates/core/block/block--article-aside-top.html.twig:38
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:147
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:157
+#: themes/contrib/gent_base/templates/core/block/block--article-aside-top.html.twig:36
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:163
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:175
 msgid "Also interesting"
 msgstr "Auch interessant"
 
@@ -268,13 +295,18 @@ msgstr "Auch interessant"
 msgid "Menu"
 msgstr ""
 
-#: themes/contrib/gent_base/templates/core/block/block--search-help.html.twig:3
+#: themes/contrib/gent_base/templates/core/block/block--search-help.html.twig:2
 msgid ""
 "As soon as you start searching, you can filter the results of your search "
 "here."
 msgstr ""
 "Wenn Sie mit der Suche anfangen, können Sie die Ergebnisse Ihrer Suche hier "
 "filtern."
+
+#: themes/contrib/gent_base/templates/core/block/block--system-branding-block.html.twig:18
+#: themes/contrib/gent_base/templates/core/layout/page.html.twig:54
+msgid "Home"
+msgstr ""
 
 #: themes/contrib/gent_base/templates/core/content/menu-local-tasks.html.twig:15
 msgid "Primary tabs"
@@ -288,33 +320,34 @@ msgstr "Sekundäre Tabs"
 msgid "Text Formats"
 msgstr "Textlayout-Typen"
 
-#: themes/contrib/gent_base/templates/core/fields/field--field-opendata-link.html.twig:51
+#: themes/contrib/gent_base/templates/core/fields/field--field-opendata-link.html.twig:49
 msgid "Related Linked Open Data"
 msgstr "Verwandte Open Data-Links"
 
-#: themes/contrib/gent_base/templates/core/fields/field--media--field-src-audio-description.html.twig:44
+#: themes/contrib/gent_base/templates/core/fields/field--media--field-src-audio-description.html.twig:45
 msgid "Watch this video with audio descripiton"
 msgstr "Dieses Video mit Audiodeskription ansehen"
 
 #: themes/contrib/gent_base/templates/core/fields/field--node--field-images.html.twig:68
+#: themes/contrib/gent_base/templates/core/fields/field--paragraph--field-image--banner-image.html.twig:68
 #: themes/contrib/gent_base/templates/core/fields/field--paragraph--field-image.html.twig:68
 msgid "Show all photos"
 msgstr "Alle Fotos ansehen"
 
-#: themes/contrib/gent_base/templates/core/form/fieldset.html.twig:50
-#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:31
+#: themes/contrib/gent_base/templates/core/form/fieldset.html.twig:48
+#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:29
 msgid "Optional"
 msgstr "Optional"
 
-#: themes/contrib/gent_base/templates/core/form/input--file.html.twig:18
+#: themes/contrib/gent_base/templates/core/form/input--file.html.twig:19
 msgid "Select your files here to upload"
 msgstr "Wählen Sie hier Ihre Dateien zum Hochladen aus"
 
-#: themes/contrib/gent_base/templates/core/layout/html.html.twig:69
+#: themes/contrib/gent_base/templates/core/layout/html.html.twig:65
 msgid "Skip to main content"
 msgstr "Überspringen und zum Inhalt"
 
-#: themes/contrib/gent_base/templates/core/layout/page.html.twig:124
+#: themes/contrib/gent_base/templates/core/layout/page.html.twig:113
 msgid "open gallery"
 msgstr "Galerie öffnen"
 
@@ -323,114 +356,125 @@ msgstr "Galerie öffnen"
 msgid "Filter the results"
 msgstr "Ergebnisse filtern"
 
-#: themes/contrib/gent_base/templates/core/navigation/breadcrumb.html.twig:16
-msgid "Breadcrumb"
-msgstr "Brotkrümelnavigation"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:34
-msgid "Pagination"
-msgstr "Paginierung"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:41
-msgid "Go to previous page"
-msgstr "Zur vorigen Seite"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:42
-msgid "Previous page"
-msgstr "Vorige Seite"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:43
-msgid "Previous"
-msgstr "Vorige"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:51
-msgid "Go to first page"
-msgstr "Zur ersten Seite"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:52
-msgid "First page"
-msgstr "Erste Seite"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:71
-msgid "Go to page @key"
-msgstr "Zur Seite @key"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:88
-msgid "Go to last page"
-msgstr "Zur letzten Seite"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:89
-msgid "Last page"
-msgstr "Letzte Seite"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:97
-msgid "Go to next page"
-msgstr "Zur nächsten Seite"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:98
-msgid "Next page"
-msgstr "Nächste Seite"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:99
-msgid "Next"
-msgstr "Nächste"
-
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:60
+#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:35
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:61
 msgid ""
 "When selecting or deselecting filters, the page is automatically reloaded."
 msgstr ""
 "Beim Auswählen oder Abwählen von Filtern wird die Seite automatisch "
 "aktualisiert."
 
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:80
+#: themes/contrib/gent_base/templates/core/navigation/breadcrumb.html.twig:17
+msgid "Breadcrumb"
+msgstr "Brotkrümelnavigation"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:35
+msgid "Pagination"
+msgstr "Paginierung"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:44
+msgid "Go to previous page"
+msgstr "Zur vorigen Seite"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:46
+msgid "Previous page"
+msgstr "Vorige Seite"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:47
+msgid "Previous"
+msgstr "Vorige"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:56
+msgid "Go to first page"
+msgstr "Zur ersten Seite"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:57
+msgid "First page"
+msgstr "Erste Seite"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:74;81
+#, fuzzy
+#| msgid "Next page"
+msgid "Current page"
+msgstr "Nächste Seite"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:74;81
+msgid "Page"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:79
+msgid "Go to page @key"
+msgstr "Zur Seite @key"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:99
+msgid "Go to last page"
+msgstr "Zur letzten Seite"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:100
+msgid "Last page"
+msgstr "Letzte Seite"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:108
+msgid "Go to next page"
+msgstr "Zur nächsten Seite"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:110
+msgid "Next page"
+msgstr "Nächste Seite"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:111
+msgid "Next"
+msgstr "Nächste"
+
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:81
 msgid "View title"
 msgstr "Titelübersicht"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:108
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:124
 msgid "Additional information"
 msgstr "Zusätzliche Informationen"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:111
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:127
 msgid "Contacts"
 msgstr "Kontakte"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:125
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:141
 #: themes/contrib/gent_base/templates/custom/nodes/node--terrain--default.html.twig:14
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:147
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:163
 msgid "Location"
 msgstr "Ort"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:129
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:145
 msgid "Authorized persons"
 msgstr "Zuständige Personen"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:139
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:155
 msgid "Documents"
 msgstr "Dokumente"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:151
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:167
 msgid "Similar articles"
 msgstr "Ähnliche Artikel"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:158
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:174
 msgid "More info about"
 msgstr "Mehr lesen über"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:171
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:186
 msgid "More news and events"
 msgstr "Mehr Nachrichten und Events"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--event--full.html.twig:42
+#: themes/contrib/gent_base/templates/custom/nodes/node--event--full.html.twig:37
 #: themes/contrib/gent_base/templates/custom/nodes/node--news--full.html.twig:12
 msgid "Last changed"
 msgstr "Vor Kurzem geändert"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--event--teaser.html.twig:14
+#: themes/contrib/gent_base/templates/custom/nodes/node--event--teaser.html.twig:15
 msgid "Event"
 msgstr "Event"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--person--full.html.twig:16
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:33
+#: themes/contrib/gent_base/templates/custom/nodes/node--person--full.html.twig:19
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:49
 msgid "Contact details"
 msgstr "Kontaktangaben"
 
@@ -438,27 +482,45 @@ msgstr "Kontaktangaben"
 msgid "Park offer"
 msgstr "Angebot und Möglichkeiten"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta--map-popup.html.twig:43
-#: themes/contrib/gent_base/templates/custom/vesta/vesta--teaser.html.twig:43
+#: themes/contrib/gent_base/templates/custom/vesta/vesta--map-popup.html.twig:45
+#: themes/contrib/gent_base/templates/custom/vesta/vesta--teaser.html.twig:45
 msgid "More info and opening hours"
 msgstr "Weitere Informationen und Öffnungszeiten"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:29
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:34
 msgid "@name - openinghours and addresses"
 msgstr "@name - Öffnungszeiten und Adressen"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:92
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:107
 msgid "(Fax)"
 msgstr "(Telefax)"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:133
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:149
 msgid "Extra information"
 msgstr "Zusätzliche Informationen"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:140
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:156
 msgid "Accessibility"
 msgstr "Erreichbarkeit"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:160
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:178
 msgid "View all locations from"
 msgstr "Rufen Sie alle Orte ab von"
+
+#~ msgid "No file chosen"
+#~ msgstr "Keine Datei"
+
+#~ msgid "Multiple files"
+#~ msgstr "Mehrere Dateien"
+
+#~ msgid "Mijn Gent"
+#~ msgstr "Mein Gent"
+
+#~ msgid "Show profile"
+#~ msgstr "Profil öffnen"
+
+#~ msgid "Show more"
+#~ msgstr "Zeig mehr"
+
+#~ msgid "Confirm selection"
+#~ msgstr "Auswahl bestätigen"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -28,16 +28,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2021-09-30 10:34+0200\n"
-"PO-Revision-Date: 2023-06-28 12:01+0200\n"
-"Last-Translator: Sven Vandevenne <sven.vandevenne@district09.gent>\n"
+"POT-Creation-Date: 2024-03-20 14:22+0100\n"
+"PO-Revision-Date: 2024-03-20 14:25+0100\n"
+"Last-Translator: Peter Decuyper <peter.decuyper@district09.gent>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: themes/contrib/gent_base/theme-settings.php:21
 msgid "Gent Base settings"
@@ -75,48 +75,40 @@ msgstr ""
 "paramètre est utilisé pour configurer correctement le favicon pour les "
 "téléphones Android + Windows et pour les ordinateurs Apple avec Touch Bar."
 
-#: themes/contrib/gent_base/gent_base.theme:288;288
+#: themes/contrib/gent_base/gent_base.theme:319;319;317
 msgid "Search"
 msgstr "Rechercher"
 
-#: themes/contrib/gent_base/gent_base.theme:430
-msgid "programme"
-msgstr "programme"
-
-#: themes/contrib/gent_base/gent_base.theme:435
-msgid "timeline"
-msgstr "ligne du temps"
-
-#: themes/contrib/gent_base/gent_base.theme:519
+#: themes/contrib/gent_base/gent_base.theme:566
 msgid "There is 1 other document"
 msgstr "Il y a 1 autre document"
 
-#: themes/contrib/gent_base/gent_base.theme:522
+#: themes/contrib/gent_base/gent_base.theme:569
 msgid "There are @count other documents"
 msgstr "Il y a @count autres documents"
 
-#: themes/contrib/gent_base/gent_base.theme:686
+#: themes/contrib/gent_base/gent_base.theme:737
 msgid "Add new files"
 msgstr "Ajouter de nouveaux fichiers"
 
-#: themes/contrib/gent_base/gent_base.theme:1187
+#: themes/contrib/gent_base/gent_base.theme:1388
 msgid "@category - All"
 msgstr "@category - Tous"
 
-#: themes/contrib/gent_base/gent_base.theme:1238
-#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:14
+#: themes/contrib/gent_base/gent_base.theme:1442
+#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:16
 msgid "View on the map"
 msgstr "Afficher sur la carte"
 
-#: themes/contrib/gent_base/gent_base.theme:1303
+#: themes/contrib/gent_base/gent_base.theme:1507
 msgid "Allowed types: @extensions."
 msgstr "Formats de fichiers autorisés: @extensions."
 
-#: themes/contrib/gent_base/gent_base.theme:1306
+#: themes/contrib/gent_base/gent_base.theme:1510
 msgid "Max filesize: @size."
 msgstr "Taille maximale du fichier: @size."
 
-#: themes/contrib/gent_base/gent_base.theme:1312
+#: themes/contrib/gent_base/gent_base.theme:1516
 msgid "Images must be larger than @min pixels."
 msgstr "Les images doivent être plus grandes que @min pixels."
 
@@ -128,16 +120,52 @@ msgstr "Gent Base"
 msgid "Ghent base theme. Always use a subtheme of this theme."
 msgstr "Thème Gent base. Utilisez toujours un sous-thème de ce thème."
 
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Administration header"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Header top"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Header bottom"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+#, fuzzy
+#| msgid "Contacts"
+msgid "Content"
+msgstr "Contacts"
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/templates/contrib/facets/facets-summary-item-list.html.twig:70
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:102
+msgid "Filters"
+msgstr "Filtres"
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Footer"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+msgid "Mobile menu"
+msgstr ""
+
 #: themes/contrib/gent_base/source/js/dg_maps.baselayerswitcher.js:0
 msgid "Legend"
 msgstr "Légende"
 
 #: themes/contrib/gent_base/source/js/dg_maps.datalayerswitcher.js:0
-#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:71
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:48
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:178
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:48
-#: themes/contrib/gent_base/templates/core/layout/page.html.twig:129
+#: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:74
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:55
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--program.html.twig:49
+#: themes/contrib/gent_base/templates/core/layout/page.html.twig:121
 #: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:29
 #: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
 msgid "Close"
@@ -148,16 +176,8 @@ msgid "No file chosen."
 msgstr "Aucun fichier."
 
 #: themes/contrib/gent_base/source/js/file.bindings.js:0
-msgid "No file chosen"
-msgstr "Aucun fichier"
-
-#: themes/contrib/gent_base/source/js/file.bindings.js:0
 msgid "Multiple files."
 msgstr "Plusieurs fichiers."
-
-#: themes/contrib/gent_base/source/js/file.bindings.js:0
-msgid "Multiple files"
-msgstr "Plusieurs fichiers"
 
 #: themes/contrib/gent_base/source/js/table.bindings.js:0
 msgid "(Scroll to see more)"
@@ -175,21 +195,13 @@ msgstr "Exemple de Sous-thème basé sur Gent Base."
 msgid "Gent"
 msgstr "Gand"
 
-#: themes/contrib/gent_base/templates/gent-base-webform.html.twig:18
-#: themes/contrib/gent_base/templates/core/form/form.html.twig:15
+#: themes/contrib/gent_base/templates/gent-base-webform.html.twig:16
+#: themes/contrib/gent_base/templates/core/form/form.html.twig:16
 msgid "Fill in all fields unless otherwise stated."
 msgstr ""
 "Tous les champs sont obligatoires, sauf s'ils sont marqués comme facultatifs."
 
-#: themes/contrib/gent_base/templates/contrib/dg-auth/dg-auth-block.html.twig:37
-msgid "Mijn Gent"
-msgstr "Mijn Gent"
-
-#: themes/contrib/gent_base/templates/contrib/dg-auth/dg-auth-block.html.twig:44
-msgid "Show profile"
-msgstr "Consulter profil"
-
-#: themes/contrib/gent_base/templates/contrib/dg_blocks/block--dg-blocks-gentinfo-block.html.twig:47
+#: themes/contrib/gent_base/templates/contrib/dg_blocks/block--dg-blocks-gentinfo-block.html.twig:46
 msgid "Chat with Gentinfo"
 msgstr "Chat avec Info Gand"
 
@@ -201,43 +213,34 @@ msgstr "Carte"
 msgid "List"
 msgstr "Liste"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:60
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:189
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:68
 msgid "Filter the list below"
 msgstr "Filtrer la liste ci-dessous"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:65
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:198
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:77
 msgid "%count filter(s) found"
 msgstr "%count filtre(s) trouvé(s)"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:98;98
-#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:38
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:113
+#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:41
 msgid "Show results"
 msgstr "Afficher les résultats"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:107
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:251
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:123
 msgid "%count item(s) selected"
 msgstr "%count élément(s) sélectionné(s)"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:112
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:130
 msgid "Select ..."
 msgstr "Sélectionner …"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:164;245
-msgid "Show more"
-msgstr "Montrer les résultats"
-
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox.html.twig:233
-msgid "Confirm selection"
-msgstr "Confirmer la sélection"
-
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--range-slider.html.twig:42
-msgid "From %min to %max year"
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--range-slider.html.twig:43
+#, fuzzy
+#| msgid "From %min to %max year"
+msgid "From %min to %max"
 msgstr "De %min à %max ans"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-result-item--summary.html.twig:24
+#: themes/contrib/gent_base/templates/contrib/facets/facets-result-item--summary.html.twig:25
 msgid "Remove this filter"
 msgstr "Supprimer ce filtre"
 
@@ -251,42 +254,66 @@ msgstr[1] "Il y a @count résultats"
 msgid "You have selected"
 msgstr "Vous avez filtré par"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-summary-item-list.html.twig:67
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:99
-msgid "Filters"
-msgstr "Filtres"
-
-#: themes/contrib/gent_base/templates/contrib/opening_hours/opening-hours-widget.html.twig:45
+#: themes/contrib/gent_base/templates/contrib/opening_hours/opening-hours-widget.html.twig:47
 msgid "All opening hours"
 msgstr "Toutes les heures d'ouverture"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/contact/paragraph--contact.html.twig:70
+#: themes/contrib/gent_base/templates/contrib/paragraphs/paragraph--contact.html.twig:70
 msgid "Call @phone"
 msgstr "Appelez @phone"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/contact/paragraph--contact.html.twig:80
-msgid "Send an email to @emailAddress"
+#: themes/contrib/gent_base/templates/contrib/paragraphs/paragraph--contact.html.twig:80
+#, fuzzy
+#| msgid "Send an email to @emailAddress"
+msgid "Send an email to @email_address"
 msgstr "Envoyez un courriel à @emailAddress"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/contact/paragraph--contact.html.twig:87
+#: themes/contrib/gent_base/templates/contrib/paragraphs/paragraph--contact.html.twig:87
 msgid "View all contact info"
 msgstr "Toutes les coordonnées"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:82
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-frame--program.html.twig:51
+msgid "programme"
+msgstr "programme"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-frame--timeline.html.twig:51
+msgid "timeline"
+msgstr "ligne du temps"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--program.html.twig:84
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:97
 msgid "More info"
 msgstr "En savoir plus"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:84
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--program.html.twig:86
 msgid "about"
 msgstr ""
 
-#: themes/contrib/gent_base/templates/contrib/webform/webform-progress-tracker.html.twig:27
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:48
+#, fuzzy
+#| msgid "More info"
+msgid "Important info"
+msgstr "En savoir plus"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:53
+msgid "Payment info"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:57
+msgid "Time-bound info"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:61
+msgid "Not to be missed info"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/contrib/webform/webform-progress-tracker.html.twig:28
 msgid "Steps in this wizard"
 msgstr "Étapes dans ce formulaire"
 
-#: themes/contrib/gent_base/templates/core/block/block--article-aside-top.html.twig:38
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:147
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:157
+#: themes/contrib/gent_base/templates/core/block/block--article-aside-top.html.twig:36
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:163
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:175
 msgid "Also interesting"
 msgstr "Également intéressant"
 
@@ -294,13 +321,18 @@ msgstr "Également intéressant"
 msgid "Menu"
 msgstr ""
 
-#: themes/contrib/gent_base/templates/core/block/block--search-help.html.twig:3
+#: themes/contrib/gent_base/templates/core/block/block--search-help.html.twig:2
 msgid ""
 "As soon as you start searching, you can filter the results of your search "
 "here."
 msgstr ""
 "Dès que vous lancez une recherche, vous pouvez filtrer ici les résultats de "
 "votre requête."
+
+#: themes/contrib/gent_base/templates/core/block/block--system-branding-block.html.twig:18
+#: themes/contrib/gent_base/templates/core/layout/page.html.twig:54
+msgid "Home"
+msgstr ""
 
 #: themes/contrib/gent_base/templates/core/content/menu-local-tasks.html.twig:15
 msgid "Primary tabs"
@@ -314,33 +346,34 @@ msgstr "Onglets secondaires"
 msgid "Text Formats"
 msgstr "Rédaction de texte"
 
-#: themes/contrib/gent_base/templates/core/fields/field--field-opendata-link.html.twig:51
+#: themes/contrib/gent_base/templates/core/fields/field--field-opendata-link.html.twig:49
 msgid "Related Linked Open Data"
 msgstr "Linked Open Data connexe"
 
-#: themes/contrib/gent_base/templates/core/fields/field--media--field-src-audio-description.html.twig:44
+#: themes/contrib/gent_base/templates/core/fields/field--media--field-src-audio-description.html.twig:45
 msgid "Watch this video with audio descripiton"
 msgstr "Visionnez cette vidéo avec audiodescription"
 
 #: themes/contrib/gent_base/templates/core/fields/field--node--field-images.html.twig:68
+#: themes/contrib/gent_base/templates/core/fields/field--paragraph--field-image--banner-image.html.twig:68
 #: themes/contrib/gent_base/templates/core/fields/field--paragraph--field-image.html.twig:68
 msgid "Show all photos"
 msgstr "Consultez toutes les photos"
 
-#: themes/contrib/gent_base/templates/core/form/fieldset.html.twig:50
-#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:31
+#: themes/contrib/gent_base/templates/core/form/fieldset.html.twig:48
+#: themes/contrib/gent_base/templates/core/form/form-element-label.html.twig:29
 msgid "Optional"
 msgstr "Facultatif"
 
-#: themes/contrib/gent_base/templates/core/form/input--file.html.twig:18
+#: themes/contrib/gent_base/templates/core/form/input--file.html.twig:19
 msgid "Select your files here to upload"
 msgstr "Sélectionnez vos fichiers ici pour télécharger"
 
-#: themes/contrib/gent_base/templates/core/layout/html.html.twig:69
+#: themes/contrib/gent_base/templates/core/layout/html.html.twig:65
 msgid "Skip to main content"
 msgstr "Passer et aller au contenu"
 
-#: themes/contrib/gent_base/templates/core/layout/page.html.twig:124
+#: themes/contrib/gent_base/templates/core/layout/page.html.twig:113
 msgid "open gallery"
 msgstr "ouvrir la galerie"
 
@@ -349,114 +382,125 @@ msgstr "ouvrir la galerie"
 msgid "Filter the results"
 msgstr "Filtrer les résultats"
 
-#: themes/contrib/gent_base/templates/core/navigation/breadcrumb.html.twig:16
-msgid "Breadcrumb"
-msgstr "Fil d'Ariane"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:34
-msgid "Pagination"
-msgstr "Pagination"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:41
-msgid "Go to previous page"
-msgstr "Aller à la page précédente"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:42
-msgid "Previous page"
-msgstr "Page précédente"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:43
-msgid "Previous"
-msgstr "Précédente"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:51
-msgid "Go to first page"
-msgstr "Aller à la première page"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:52
-msgid "First page"
-msgstr "Première page"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:71
-msgid "Go to page @key"
-msgstr "Aller à la page @key"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:88
-msgid "Go to last page"
-msgstr "Aller à la dernière page"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:89
-msgid "Last page"
-msgstr "Dernière page"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:97
-msgid "Go to next page"
-msgstr "Aller à la page suivante"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:98
-msgid "Next page"
-msgstr "Page suivante"
-
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:99
-msgid "Next"
-msgstr "Suivante"
-
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:60
+#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:35
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:61
 msgid ""
 "When selecting or deselecting filters, the page is automatically reloaded."
 msgstr ""
 "La page est automatiquement rechargée lorsque des filtres sont sélectionnés "
 "ou désélectionnés."
 
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:80
+#: themes/contrib/gent_base/templates/core/navigation/breadcrumb.html.twig:17
+msgid "Breadcrumb"
+msgstr "Fil d'Ariane"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:35
+msgid "Pagination"
+msgstr "Pagination"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:44
+msgid "Go to previous page"
+msgstr "Aller à la page précédente"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:46
+msgid "Previous page"
+msgstr "Page précédente"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:47
+msgid "Previous"
+msgstr "Précédente"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:56
+msgid "Go to first page"
+msgstr "Aller à la première page"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:57
+msgid "First page"
+msgstr "Première page"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:74;81
+#, fuzzy
+#| msgid "Next page"
+msgid "Current page"
+msgstr "Page suivante"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:74;81
+msgid "Page"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:79
+msgid "Go to page @key"
+msgstr "Aller à la page @key"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:99
+msgid "Go to last page"
+msgstr "Aller à la dernière page"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:100
+msgid "Last page"
+msgstr "Dernière page"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:108
+msgid "Go to next page"
+msgstr "Aller à la page suivante"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:110
+msgid "Next page"
+msgstr "Page suivante"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:111
+msgid "Next"
+msgstr "Suivante"
+
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:81
 msgid "View title"
 msgstr "Titre de l'aperçu"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:108
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:124
 msgid "Additional information"
 msgstr "Informations complémentaires"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:111
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:127
 msgid "Contacts"
 msgstr "Contacts"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:125
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:141
 #: themes/contrib/gent_base/templates/custom/nodes/node--terrain--default.html.twig:14
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:147
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:163
 msgid "Location"
 msgstr "Lieu"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:129
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:145
 msgid "Authorized persons"
 msgstr "Personnes compétentes"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:139
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:155
 msgid "Documents"
 msgstr "Documents"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:151
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:167
 msgid "Similar articles"
 msgstr "Articles similaires"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:158
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:174
 msgid "More info about"
 msgstr "En savoir plus"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:171
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:186
 msgid "More news and events"
 msgstr "Plus d'actualités et d'événements"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--event--full.html.twig:42
+#: themes/contrib/gent_base/templates/custom/nodes/node--event--full.html.twig:37
 #: themes/contrib/gent_base/templates/custom/nodes/node--news--full.html.twig:12
 msgid "Last changed"
 msgstr "Dernière modification"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--event--teaser.html.twig:14
+#: themes/contrib/gent_base/templates/custom/nodes/node--event--teaser.html.twig:15
 msgid "Event"
 msgstr "Événement"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--person--full.html.twig:16
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:33
+#: themes/contrib/gent_base/templates/custom/nodes/node--person--full.html.twig:19
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:49
 msgid "Contact details"
 msgstr "Coordonnées"
 
@@ -464,27 +508,45 @@ msgstr "Coordonnées"
 msgid "Park offer"
 msgstr "Offre et possibilités"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta--map-popup.html.twig:43
-#: themes/contrib/gent_base/templates/custom/vesta/vesta--teaser.html.twig:43
+#: themes/contrib/gent_base/templates/custom/vesta/vesta--map-popup.html.twig:45
+#: themes/contrib/gent_base/templates/custom/vesta/vesta--teaser.html.twig:45
 msgid "More info and opening hours"
 msgstr "Plus d'infos et heures d'ouverture"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:29
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:34
 msgid "@name - openinghours and addresses"
 msgstr "@name - Heures d'ouverture et adresses"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:92
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:107
 msgid "(Fax)"
 msgstr "(Fax)"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:133
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:149
 msgid "Extra information"
 msgstr "Informations complémentaires"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:140
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:156
 msgid "Accessibility"
 msgstr "Accessibilité"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:160
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:178
 msgid "View all locations from"
 msgstr "Afficher tous les lieux de"
+
+#~ msgid "No file chosen"
+#~ msgstr "Aucun fichier"
+
+#~ msgid "Multiple files"
+#~ msgstr "Plusieurs fichiers"
+
+#~ msgid "Mijn Gent"
+#~ msgstr "Mijn Gent"
+
+#~ msgid "Show profile"
+#~ msgstr "Consulter profil"
+
+#~ msgid "Show more"
+#~ msgstr "Montrer les résultats"
+
+#~ msgid "Confirm selection"
+#~ msgstr "Confirmer la sélection"

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -42,16 +42,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2022-11-09 16:38+0100\n"
-"PO-Revision-Date: 2023-06-28 12:00+0200\n"
-"Last-Translator: Sven Vandevenne <sven.vandevenne@district09.gent>\n"
+"POT-Creation-Date: 2024-03-20 14:22+0100\n"
+"PO-Revision-Date: 2024-03-20 14:25+0100\n"
+"Last-Translator: Peter Decuyper <peter.decuyper@district09.gent>\n"
 "Language-Team: Digipolis <tbweb@gent.be>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: themes/contrib/gent_base/theme-settings.php:21
 msgid "Gent Base settings"
@@ -89,48 +89,40 @@ msgstr ""
 "favicon correct in te stellen voor Android + Windows telefoons en voor "
 "Apple's computers met Touch Bar."
 
-#: themes/contrib/gent_base/gent_base.theme:289;289
+#: themes/contrib/gent_base/gent_base.theme:319;319;317
 msgid "Search"
 msgstr "Zoeken"
 
-#: themes/contrib/gent_base/gent_base.theme:443
-msgid "programme"
-msgstr "programma"
-
-#: themes/contrib/gent_base/gent_base.theme:448
-msgid "timeline"
-msgstr "tijdslijn"
-
-#: themes/contrib/gent_base/gent_base.theme:532
+#: themes/contrib/gent_base/gent_base.theme:566
 msgid "There is 1 other document"
 msgstr "Er is 1 ander document"
 
-#: themes/contrib/gent_base/gent_base.theme:535
+#: themes/contrib/gent_base/gent_base.theme:569
 msgid "There are @count other documents"
 msgstr "Er zijn @count andere documenten"
 
-#: themes/contrib/gent_base/gent_base.theme:701
+#: themes/contrib/gent_base/gent_base.theme:737
 msgid "Add new files"
 msgstr "Voeg nieuwe bestanden toe"
 
-#: themes/contrib/gent_base/gent_base.theme:1203
+#: themes/contrib/gent_base/gent_base.theme:1388
 msgid "@category - All"
 msgstr "@category - Alle"
 
-#: themes/contrib/gent_base/gent_base.theme:1257
+#: themes/contrib/gent_base/gent_base.theme:1442
 #: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map-region.html.twig:16
 msgid "View on the map"
 msgstr "Toon op de kaart"
 
-#: themes/contrib/gent_base/gent_base.theme:1322
+#: themes/contrib/gent_base/gent_base.theme:1507
 msgid "Allowed types: @extensions."
 msgstr "Toegestane bestandsformaten: @extensions."
 
-#: themes/contrib/gent_base/gent_base.theme:1325
+#: themes/contrib/gent_base/gent_base.theme:1510
 msgid "Max filesize: @size."
 msgstr "Maximum bestandsgrootte: @size."
 
-#: themes/contrib/gent_base/gent_base.theme:1331
+#: themes/contrib/gent_base/gent_base.theme:1516
 msgid "Images must be larger than @min pixels."
 msgstr "Afbeeldingen moeten groter zijn dan @min pixels."
 
@@ -142,15 +134,52 @@ msgstr "Gent Base"
 msgid "Ghent base theme. Always use a subtheme of this theme."
 msgstr "Gent base theme. Gebruik altijd een subthema van dit thema."
 
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Administration header"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Header top"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Header bottom"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+#, fuzzy
+#| msgid "Contacts"
+msgid "Content"
+msgstr "Contacten"
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/templates/contrib/facets/facets-summary-item-list.html.twig:70
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:102
+msgid "Filters"
+msgstr "Filters"
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+#: themes/contrib/gent_base/starterkit/starterkit.info.yml:0
+msgid "Footer"
+msgstr ""
+
+#: themes/contrib/gent_base/gent_base.info.yml:0
+msgid "Mobile menu"
+msgstr ""
+
 #: themes/contrib/gent_base/source/js/dg_maps.baselayerswitcher.js:0
 msgid "Legend"
 msgstr "Legende"
 
 #: themes/contrib/gent_base/source/js/dg_maps.datalayerswitcher.js:0
 #: themes/contrib/gent_base/templates/contrib/dg_maps/dg-maps-map.html.twig:74
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:56
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:50
-#: themes/contrib/gent_base/templates/core/layout/page.html.twig:130
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:55
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--program.html.twig:49
+#: themes/contrib/gent_base/templates/core/layout/page.html.twig:121
 #: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:29
 #: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:55
 msgid "Close"
@@ -161,16 +190,8 @@ msgid "No file chosen."
 msgstr "Nog geen bestand."
 
 #: themes/contrib/gent_base/source/js/file.bindings.js:0
-msgid "No file chosen"
-msgstr "Nog geen bestand"
-
-#: themes/contrib/gent_base/source/js/file.bindings.js:0
 msgid "Multiple files."
 msgstr "Meerdere bestanden."
-
-#: themes/contrib/gent_base/source/js/file.bindings.js:0
-msgid "Multiple files"
-msgstr "Meerdere bestanden"
 
 #: themes/contrib/gent_base/source/js/table.bindings.js:0
 msgid "(Scroll to see more)"
@@ -193,14 +214,6 @@ msgstr "Gent"
 msgid "Fill in all fields unless otherwise stated."
 msgstr "Alle velden zijn verplicht, tenzij anders aangegeven."
 
-#: themes/contrib/gent_base/templates/contrib/dg-auth/dg-auth-block.html.twig:37
-msgid "Mijn Gent"
-msgstr "Mijn Gent"
-
-#: themes/contrib/gent_base/templates/contrib/dg-auth/dg-auth-block.html.twig:45
-msgid "Show profile"
-msgstr "Bekijk profiel"
-
 #: themes/contrib/gent_base/templates/contrib/dg_blocks/block--dg-blocks-gentinfo-block.html.twig:46
 msgid "Chat with Gentinfo"
 msgstr "Chat met Gentinfo"
@@ -213,24 +226,24 @@ msgstr "Kaart"
 msgid "List"
 msgstr "Lijst"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:69
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:68
 msgid "Filter the list below"
 msgstr "Filter onderstaande lijst"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:78
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:77
 msgid "%count filter(s) found"
 msgstr "%count filter(s) gevonden"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:114
-#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:40
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:113
+#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:41
 msgid "Show results"
 msgstr "Toon resultaten"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:124
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:123
 msgid "%count item(s) selected"
 msgstr "%count item(s) geselecteerd"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:131
+#: themes/contrib/gent_base/templates/contrib/facets/facets-item-list--checkbox-popup.html.twig:130
 msgid "Select ..."
 msgstr "Selecteer …"
 
@@ -252,42 +265,64 @@ msgstr[1] "Er zijn @count resultaten"
 msgid "You have selected"
 msgstr "Je filterde op"
 
-#: themes/contrib/gent_base/templates/contrib/facets/facets-summary-item-list.html.twig:70
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:102
-msgid "Filters"
-msgstr "Filters"
-
 #: themes/contrib/gent_base/templates/contrib/opening_hours/opening-hours-widget.html.twig:47
 msgid "All opening hours"
 msgstr "Alle openingsuren"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/contact/paragraph--contact.html.twig:70
+#: themes/contrib/gent_base/templates/contrib/paragraphs/paragraph--contact.html.twig:70
 msgid "Call @phone"
 msgstr "Bel naar @phone"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/contact/paragraph--contact.html.twig:80
+#: themes/contrib/gent_base/templates/contrib/paragraphs/paragraph--contact.html.twig:80
 msgid "Send an email to @email_address"
 msgstr "Stuur een email naar @email_address"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/contact/paragraph--contact.html.twig:87
+#: themes/contrib/gent_base/templates/contrib/paragraphs/paragraph--contact.html.twig:87
 msgid "View all contact info"
 msgstr "Alle contactgegevens"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:86
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-frame--program.html.twig:51
+msgid "programme"
+msgstr "programma"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-frame--timeline.html.twig:51
+msgid "timeline"
+msgstr "tijdslijn"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--program.html.twig:84
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:97
 msgid "More info"
 msgstr "Meer weten"
 
-#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--alt.html.twig:88
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--program.html.twig:86
 msgid "about"
 msgstr "over"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:48
+#, fuzzy
+#| msgid "More info"
+msgid "Important info"
+msgstr "Meer weten"
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:53
+msgid "Payment info"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:57
+msgid "Time-bound info"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/contrib/paragraphs/timeline/paragraph--timeline-item--roadmap.html.twig:61
+msgid "Not to be missed info"
+msgstr ""
 
 #: themes/contrib/gent_base/templates/contrib/webform/webform-progress-tracker.html.twig:28
 msgid "Steps in this wizard"
 msgstr "Stappen in dit formulier"
 
 #: themes/contrib/gent_base/templates/core/block/block--article-aside-top.html.twig:36
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:145
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:160
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:163
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:175
 msgid "Also interesting"
 msgstr "Ook interessant"
 
@@ -295,13 +330,18 @@ msgstr "Ook interessant"
 msgid "Menu"
 msgstr "Menu"
 
-#: themes/contrib/gent_base/templates/core/block/block--search-help.html.twig:3
+#: themes/contrib/gent_base/templates/core/block/block--search-help.html.twig:2
 msgid ""
 "As soon as you start searching, you can filter the results of your search "
 "here."
 msgstr ""
 "Van zodra u begint te zoeken, kan u de resultaten van uw zoekopdracht hier "
 "filteren."
+
+#: themes/contrib/gent_base/templates/core/block/block--system-branding-block.html.twig:18
+#: themes/contrib/gent_base/templates/core/layout/page.html.twig:54
+msgid "Home"
+msgstr ""
 
 #: themes/contrib/gent_base/templates/core/content/menu-local-tasks.html.twig:15
 msgid "Primary tabs"
@@ -324,6 +364,7 @@ msgid "Watch this video with audio descripiton"
 msgstr "Bekijk deze video met audiodescriptie"
 
 #: themes/contrib/gent_base/templates/core/fields/field--node--field-images.html.twig:68
+#: themes/contrib/gent_base/templates/core/fields/field--paragraph--field-image--banner-image.html.twig:68
 #: themes/contrib/gent_base/templates/core/fields/field--paragraph--field-image.html.twig:68
 msgid "Show all photos"
 msgstr "Bekijk alle foto's"
@@ -337,11 +378,11 @@ msgstr "Optioneel"
 msgid "Select your files here to upload"
 msgstr "Kies bestanden om op te laden"
 
-#: themes/contrib/gent_base/templates/core/layout/html.html.twig:75
+#: themes/contrib/gent_base/templates/core/layout/html.html.twig:65
 msgid "Skip to main content"
 msgstr "Overslaan en naar de inhoud gaan"
 
-#: themes/contrib/gent_base/templates/core/layout/page.html.twig:122
+#: themes/contrib/gent_base/templates/core/layout/page.html.twig:113
 msgid "open gallery"
 msgstr "galerij openen"
 
@@ -349,6 +390,14 @@ msgstr "galerij openen"
 #: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:59
 msgid "Filter the results"
 msgstr "Filter de resultaten"
+
+#: themes/contrib/gent_base/templates/core/layout/region--filters.html.twig:35
+#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:61
+msgid ""
+"When selecting or deselecting filters, the page is automatically reloaded."
+msgstr ""
+"Bij selecteren of deselecteren van filters wordt de pagina automatisch "
+"herladen."
 
 #: themes/contrib/gent_base/templates/core/navigation/breadcrumb.html.twig:17
 msgid "Breadcrumb"
@@ -358,106 +407,109 @@ msgstr "Kruimelpad"
 msgid "Pagination"
 msgstr "Paginering"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:43
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:44
 msgid "Go to previous page"
 msgstr "Ga naar vorige pagina"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:45
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:46
 msgid "Previous page"
 msgstr "Vorige pagina"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:46
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:47
 msgid "Previous"
 msgstr "Vorige"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:55
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:56
 msgid "Go to first page"
 msgstr "Ga naar de eerste pagina"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:56
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:57
 msgid "First page"
 msgstr "Eerste pagina"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:78
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:74;81
+#, fuzzy
+#| msgid "Next page"
+msgid "Current page"
+msgstr "Volgende pagina"
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:74;81
+msgid "Page"
+msgstr ""
+
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:79
 msgid "Go to page @key"
 msgstr "Ga naar pagina @key"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:98
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:99
 msgid "Go to last page"
 msgstr "Ga naar de laatste pagina"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:99
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:100
 msgid "Last page"
 msgstr "Laatste pagina"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:107
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:108
 msgid "Go to next page"
 msgstr "Ga naar volgende pagina"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:109
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:110
 msgid "Next page"
 msgstr "Volgende pagina"
 
-#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:110
+#: themes/contrib/gent_base/templates/core/navigation/pager.html.twig:111
 msgid "Next"
 msgstr "Volgende"
-
-#: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:61
-msgid ""
-"When selecting or deselecting filters, the page is automatically reloaded."
-msgstr ""
-"Bij selecteren of deselecteren van filters wordt de pagina automatisch "
-"herladen."
 
 #: themes/contrib/gent_base/templates/core/views/views-with-sidebar-layout.html.twig:81
 msgid "View title"
 msgstr "Overzicht titel"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:106
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:124
 msgid "Additional information"
 msgstr "Bijkomende informatie"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:109
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:127
 msgid "Contacts"
 msgstr "Contacten"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:123
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:141
 #: themes/contrib/gent_base/templates/custom/nodes/node--terrain--default.html.twig:14
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:150
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:163
 msgid "Location"
 msgstr "Locatie"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:127
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:145
 msgid "Authorized persons"
 msgstr "Bevoegde personen"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:137
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:155
 msgid "Documents"
 msgstr "Documenten"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:149
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:167
 msgid "Similar articles"
 msgstr "Vergelijkbare artikels"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:156
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:174
 msgid "More info about"
 msgstr "Lees meer over"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:169
+#: themes/contrib/gent_base/templates/custom/nodes/node--detail--layout.html.twig:186
 msgid "More news and events"
 msgstr "Meer nieuws en evenementen"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--event--full.html.twig:44
-#: themes/contrib/gent_base/templates/custom/nodes/node--news--full.html.twig:13
+#: themes/contrib/gent_base/templates/custom/nodes/node--event--full.html.twig:37
+#: themes/contrib/gent_base/templates/custom/nodes/node--news--full.html.twig:12
 msgid "Last changed"
 msgstr "Laatst gewijzigd"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--event--teaser.html.twig:14
+#: themes/contrib/gent_base/templates/custom/nodes/node--event--teaser.html.twig:15
 msgid "Event"
 msgstr "Evenement"
 
-#: themes/contrib/gent_base/templates/custom/nodes/node--person--full.html.twig:16
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:32
+#: themes/contrib/gent_base/templates/custom/nodes/node--person--full.html.twig:19
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:49
 msgid "Contact details"
 msgstr "Contactgegevens"
 
@@ -470,22 +522,34 @@ msgstr "Aanbod en mogelijkheden"
 msgid "More info and opening hours"
 msgstr "Meer info en openingsuren"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:27
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:34
 msgid "@name - openinghours and addresses"
 msgstr "@name - openingsuren en adressen"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:91
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:107
 msgid "(Fax)"
 msgstr "(Fax)"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:136
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:149
 msgid "Extra information"
 msgstr "Extra informatie"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:143
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:156
 msgid "Accessibility"
 msgstr "Bereikbaarheid"
 
-#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:163
+#: themes/contrib/gent_base/templates/custom/vesta/vesta.html.twig:178
 msgid "View all locations from"
 msgstr "Alle locaties van"
+
+#~ msgid "No file chosen"
+#~ msgstr "Nog geen bestand"
+
+#~ msgid "Multiple files"
+#~ msgstr "Meerdere bestanden"
+
+#~ msgid "Mijn Gent"
+#~ msgstr "Mijn Gent"
+
+#~ msgid "Show profile"
+#~ msgstr "Bekijk profiel"


### PR DESCRIPTION
## Description

The filter section title is to large (not same heading size as in style guide) and help text is missing.

## Motivation and Context

- Correct display of the filter title (as in style guide).
- Inform the user about how the filters work.

![stijlgids-figma-filters](https://github.com/StadGent/drupal_theme_gent-base/assets/133124/876af199-9497-43e4-833b-43284a7ecdb9)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
