### PR TITLE
DTGB-908: Fix multiple menu-bindings execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All Notable changes to `StadGent/drupal_theme_gent-base`.
 - DTGB-904: Fix gap in filter modal (fixed in Styleguide).
 - DTGB-905: Fix filters heading size and missing help text.
 - Remove word-break on language switcher links.
+- DTGB-908: Fix multiple menu-bindings execution due to other modals on page.
 
 ## [5.x]
 

--- a/gent_base.libraries.yml
+++ b/gent_base.libraries.yml
@@ -3,6 +3,7 @@ menu:
     source/js/menu.bindings.js: {}
   dependencies:
     - gent_base/modal
+    - core/once
 
 accordion:
   js:

--- a/source/js/menu.bindings.js
+++ b/source/js/menu.bindings.js
@@ -1,6 +1,6 @@
 /**
  * @file
-* Menu component binding.
+ * Menu component binding.
  */
 (function (Drupal) {
   'use strict';
@@ -11,30 +11,23 @@
         return;
       }
 
-      var menu = document.querySelectorAll('.modal.menu');
-
-      var createModal = function (modal) {
-        /* global Modal */
-        new Modal(modal, {
-          // The modal is always visible from tablet and up,
+      once('gent-base-menu', '.modal.menu', context).forEach(menu => {
+        new Modal(menu, {
+          // The menu is always visible from tablet and up,
           // this is atypical.
           resizeEvent: function (open, close) {
             if (window.innerWidth > 960) {
               close();
-              modal.setAttribute('aria-hidden', 'false');
+              menu.setAttribute('aria-hidden', 'false');
+              return;
             }
-            else {
-              if (!modal.classList.contains('visible')) {
-                modal.setAttribute('aria-hidden', 'true');
-              }
+
+            if (!menu.classList.contains('visible')) {
+              menu.setAttribute('aria-hidden', 'true');
             }
           }
         });
-      };
-
-      for (var i = menu.length; i--;) {
-        createModal(menu[i]);
-      }
+      });
     }
   };
-})(Drupal);
+})(Drupal, once);


### PR DESCRIPTION
## Description

The menu binding was run for every modal on the page. This resulted in a none removed overflow-hidden on the body once the menu was opened and closed.

## Motivation and Context

Bug.

## How Has This Been Tested?

Detected and fixed for the Gentse Feesten 2024 website.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the gent_base CHANGELOG accordingly.
