### PR TITLE
Remove source folder after build

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,3 +38,6 @@ mkdir -p ../build/@digipolis-gent/modal;
 cp -R ./node_modules/@digipolis-gent/modal/dist/index.js ../build/@digipolis-gent/modal;
 cp -R ./node_modules/gent_styleguide/build/styleguide ../build;
 ./node_modules/.bin/gulp build;
+
+echo "Removing gent_base 'source' directory...";
+rm -rf ../source;


### PR DESCRIPTION
After the build process is done, we have no more need for the source folder. Deleting it saves us around 150MB on the server where it is deployed, for each release we do.
