### PR TITLE
SPOS-541: Add OIDC menu styling

### DIFF
--- a/source/sass/31-molecules/oidc-menu/_oidc-menu.scss
+++ b/source/sass/31-molecules/oidc-menu/_oidc-menu.scss
@@ -2,7 +2,7 @@
    OIDC Menu block
    ========================================================================== */
 
-.authentication {
+.oidc-menu--wrapper {
   display: flex;
   position: relative;
   justify-content: flex-end;

--- a/source/sass/31-molecules/oidc-menu/_oidc-menu.scss
+++ b/source/sass/31-molecules/oidc-menu/_oidc-menu.scss
@@ -1,0 +1,161 @@
+/* ==========================================================================
+   OIDC Menu block
+   ========================================================================== */
+
+.authentication {
+  display: flex;
+  position: relative;
+  justify-content: flex-end;
+
+  .avatar {
+    @include bold-text;
+    @include theme('background-color', 'color-secondary');
+    @include theme('color', 'color-zero');
+
+    flex-shrink: 0;
+    width: 2.3rem;
+    height: 2.3rem;
+    border-radius: 50%;
+    font-size: 1.3rem;
+    line-height: 2.3rem;
+    text-align: center;
+    text-transform: uppercase;
+  }
+
+  .login-link {
+    @include icon(user, before);
+
+    position: relative;
+    margin-left: 1.6rem;
+    line-height: 1;
+    text-overflow: ellipsis;
+
+    &::before {
+      @include theme('color', 'color-tertiary', 'login-link-icon-color');
+
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: -1.6rem;
+    }
+  }
+
+  img {
+    border-radius: 50%;
+  }
+
+  .accordion--button {
+    display: flex;
+    align-items: center;
+    border: 0;
+    background: transparent;
+    font-size: .8rem;
+    cursor: pointer;
+
+    * {
+      vertical-align: middle;
+    }
+
+    img {
+      width: 2.3rem;
+      height: 2.3rem;
+      object-fit: cover;
+    }
+
+    span {
+      @include bold-text;
+
+      display: none;
+      max-width: 160px;
+      padding: 0 .5em;
+      text-overflow: ellipsis;
+      overflow: hidden;
+
+      @include tablet {
+        display: inline-block;
+      }
+    }
+
+    &::before {
+      line-height: 0;
+    }
+
+    span.avatar {
+      display: block;
+    }
+  }
+
+  .accordion--content {
+    @include theme('background-color', 'color-none');
+
+    position: absolute;
+    top: 100%;
+    right: 0;
+    width: calc(100vw - 2 * #{$gutter-width});
+    max-width: $bp-mobile;
+    margin-top: .5rem;
+    transition: max-height .3s ease-in-out;
+    border-radius: border-radius('radius-1');
+    box-shadow: 0 0 20px 0 rgba(color('gray-medium'), 0.25);
+    z-index: 6;
+  }
+
+  .content {
+    padding: 1.2rem;
+
+    h2 {
+      @extend %h3;
+    }
+
+    > h2 {
+      margin-bottom: 0;
+    }
+
+    section {
+      @include theme('border-color', 'color-primary--lighten-4', 'mijn_gent-border-color');
+
+      padding: .6rem 0;
+      border-top: 2px solid;
+
+      .links {
+        margin: 0;
+
+        ///
+        /// All links shouldn't have an indicator.
+        ///
+        a {
+          @include reset-link-background;
+          @include link-underlined;
+        }
+      }
+    }
+
+    .profile {
+      display: flex;
+      padding-bottom: 1rem;
+      border-top: 0;
+
+      &-info {
+        span {
+          display: block;
+          font-size: .7rem;
+        }
+      }
+
+      img {
+        align-self: flex-start;
+        width: 3.3rem;
+        height: 3.3rem;
+        margin-right: $gutter-width;
+        object-fit: cover;
+      }
+
+      .avatar {
+        width: 3.3rem;
+        height: 3.3rem;
+        margin-right: 1.2rem;
+        line-height: 3.3rem;
+      }
+    }
+  }
+}

--- a/templates/contrib/oidc_menu/oidc-menu-anonymous.html.twig
+++ b/templates/contrib/oidc_menu/oidc-menu-anonymous.html.twig
@@ -1,3 +1,9 @@
-<div{{ attributes.addClass(['authentication', 'accordion']) }}>
+{% set classes = [
+    'authentication',
+    'accordion',
+    'oidc-menu--wrapper'
+] %}
+
+<div{{ attributes.addClass(classes) }}>
   {{ login_link }}
 </div>

--- a/templates/contrib/oidc_menu/oidc-menu-authenticated.html.twig
+++ b/templates/contrib/oidc_menu/oidc-menu-authenticated.html.twig
@@ -2,7 +2,13 @@
 
 {% set id = 'no-hero_auth-authentication' %}
 
-<div{{ attributes.addClass(['authentication', 'accordion']) }}>
+{% set classes = [
+    'authentication',
+    'accordion',
+    'oidc-menu--wrapper'
+] %}
+
+<div{{ attributes.addClass(classes) }}>
   <button aria-expanded="false" aria-controls="{{ id }}"
           class="toggle accordion--button">
     <span class="avatar">{{ username|striptags|first }}</span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add the styling for OIDC menu to GB instead of Styleguide
- Changed some colors
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
