### PR TITLE
SGD8-2912: Fix double encoding in quote

### DIFF
--- a/templates/contrib/paragraphs/paragraph--quote.html.twig
+++ b/templates/contrib/paragraphs/paragraph--quote.html.twig
@@ -45,10 +45,10 @@
 
 {% set author = [] %}
 {% if content.field_author|render|striptags|trim is not empty %}
-  {% set author = author|merge([content.field_author|render|striptags|trim]) %}
+  {% set author = author|merge([content.field_author['#markup']|default(content.field_author|render)|striptags|trim|raw]) %}
 {% endif %}
 {% if content.field_position|render|striptags|trim is not empty %}
-  {% set author = author|merge([content.field_position|render|striptags|trim]) %}
+  {% set author = author|merge([content.field_position['#markup']|default(content.field_position|render)|striptags|trim|raw]) %}
 {% endif %}
 
 <div{{ attributes.addClass(classes) }}>
@@ -66,7 +66,7 @@
       {% endblock %}
       {% if author is not empty %}
         <footer>
-          {{ author|join(', ') }}
+          {{ author|join(', ')|raw }}
         </footer>
       {% endif %}
     </blockquote>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the following:
![image](https://github.com/user-attachments/assets/803b9c2a-63be-4bc2-89ad-c76354680b02)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
