### PR TITLE
HEAT-6798135: Fix capitalization vesta mail notes

### DIFF
--- a/templates/custom/vesta/vesta.html.twig
+++ b/templates/custom/vesta/vesta.html.twig
@@ -118,7 +118,7 @@
               <i class="icon-envelope" aria-hidden="true"></i>
               <span>
                 {% if email.note is not empty %}
-                  {{ email.note|capitalize }}:&nbsp;
+                  {{ email.note[:1]|upper ~ email.note[1:] }}:&nbsp;
                 {% endif %}
                 <a class="no-icon" href="mailto:{{ email.value }}">{{ email.value }}</a>
               </span>


### PR DESCRIPTION
Twig's `capitalize` filter makes the first letter uppercase, but _all_ other letters lowercase. This was probably added for single-word labels like "e-mail" or "contact", to make it consistent. But in some cases the key users use entire sentences, and this filter makes the letters after punctiation lowercase, which isn't right. This commit replaces the `capitalize` filter with Twig's equivalent of `ucfirst`. This way we keep backward compatibility for single-word labels, but we also make sure lables with entire sentences are displayed correctly.
