### PR TITLE
Fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ node_js:
 
 env:
   matrix:
-    - DRUPAL=9.4 PHPUNIT=9
     - DRUPAL=10.3 PHPUNIT=9
+    - DRUPAL=10.4 PHPUNIT=9
 
 jobs:
   fast_finish: true
@@ -40,7 +40,7 @@ before_install:
 
 install:
   # Set the proper Drupal core & PHPUnit version.
-  - composer require -n --no-update --sort-packages --dev --with-all-dependencies "drupal/core:~$DRUPAL.0" "phpunit/phpunit:^$PHPUNIT"
+  - composer require -n --no-update --sort-packages --dev --with-all-dependencies "drupal/core:~$DRUPAL.0" "phpunit/phpunit:^$PHPUNIT" "drupal/paragraphs" "gent-drupal/dg_vesta"
   # Install the module dependencies.
   - composer install -n --no-progress
 

--- a/includes/theme.inc
+++ b/includes/theme.inc
@@ -5,6 +5,7 @@
  * Helper functions to support theming in the Gent Base theme.
  */
 
+use Drupal\Core\StringTranslation\ByteSizeMarkup;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
 use Drupal\paragraphs\Entity\Paragraph;
@@ -94,7 +95,7 @@ function _gent_base_get_entity_reference_file_data(&$variables, $field) {
   $file_type = end($file_type);
   $file_type = strtoupper($file_type);
 
-  $data['file_size'] = format_size($file_entity->getSize());
+  $data['file_size'] = ByteSizeMarkup::create($file_entity->getSize());
 
   $wrapper = \Drupal::service('stream_wrapper_manager')->getViaUri($file_entity->getFileUri());
   if ($wrapper) {


### PR DESCRIPTION
- Require all soft dependencies so phpstan doesn't complain about unknown classes
- Update deprecated code to their supported alternatives
- Drop tests for Drupal 9, the theme no longer supports it
- Add tests for Drupal 10.4
