### PR TITLE
Update gent_styleguide to 6.0.3 to revert button styling fix

### DIFF
--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -3152,9 +3152,9 @@
       }
     },
     "node_modules/gent_styleguide": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/gent_styleguide/-/gent_styleguide-6.0.2.tgz",
-      "integrity": "sha512-eGDgrVRagAzkJ7rjU+MipclgxF9AwwRO0LTqEknP2frg0+B/rnR7UZ0z7ZVKdy65xPh+y+9ZWABytR8yyPxrYQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/gent_styleguide/-/gent_styleguide-6.0.3.tgz",
+      "integrity": "sha512-SrctGTiLlk2Aav7FRbDu+jK9W+JXyFI2v/HbUwRdLp/oxAo+NbNUUGwgdjz3ZclF2rA9LHGnELFW8OKc9cwb2A==",
       "hasInstallScript": true,
       "dependencies": {
         "@digipolis-gent/modal": "^1.0.4",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A 'disabled' button styling fix introduced visual faults. This update reverts this.

<img width="713" alt="Screenshot 2025-02-28 at 11 31 40" src="https://github.com/user-attachments/assets/46b37e6f-1dcf-420c-bcfb-696944f56305" />


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
