### PR TITLE
SGD8-2965: Add overlap in Event content-header

### DIFF
--- a/gent_base.theme
+++ b/gent_base.theme
@@ -955,6 +955,16 @@ function _gent_base_preprocess_content_header_classes(&$variables) {
  *   True if overlap occurs.
  */
 function _gent_base_node_has_overlapped_header(NodeInterface $node, array $bundles, array $overlappingParagraphs) {
+  // For events with a date box, the date box will always overlap the header.
+  if ($node->bundle() === 'event'
+    && $node->hasField('field_event_date')
+    && !$node->get('field_event_date')->isEmpty()
+  ) {
+    return TRUE;
+  }
+
+  // Loop through bundles and check for first paragraphs that should overlap
+  // the header box.
   if (in_array($node->bundle(), $bundles) && $node->hasField('field_paragraphs')) {
     $paragraphs = $node->get('field_paragraphs')->referencedEntities();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add overlap class to content-headers on node type events with event date filled in (in summary box in FE)
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
