### PR TITLE
SGD8-3032: Fix CTA with secondary document with empty title field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to `StadGent/drupal_theme_gent-base`.
 
+## [6.0.8]
+
+### Fixed
+
+- SGD8-3032: Fix 500 error for CTA with secondary document with empty title field.
+
 ## [6.0.7]
 
 ### Fixed
@@ -797,6 +803,7 @@ See Github releases for more information.
 
 * **Updated to gent_styleguide version 2.6.13**
 
+[6.0.8]: https://github.com/StadGent/drupal_theme_gent-base/compare/6.0.7...6.0.8
 [6.0.7]: https://github.com/StadGent/drupal_theme_gent-base/compare/6.0.6...6.0.7
 [6.0.6]: https://github.com/StadGent/drupal_theme_gent-base/compare/6.0.5...6.0.6
 [6.0.5]: https://github.com/StadGent/drupal_theme_gent-base/compare/6.0.4...6.0.5

--- a/gent_base.theme
+++ b/gent_base.theme
@@ -1370,7 +1370,7 @@ function gent_base_preprocess_paragraph__call_to_action(&$variables) {
 
     $action = [
       '#type' => 'link',
-      '#title' => $paragraph->get($field . '_title')->value,
+      '#title' => $paragraph->get($field . '_title')->getString(),
       '#attributes' => [
         'class' => $i > 0 ? ['standalone-link'] : ['button', 'button-secondary'],
       ],
@@ -1393,6 +1393,7 @@ function gent_base_preprocess_paragraph__call_to_action(&$variables) {
         break;
       }
 
+      $action['#title'] = $action['#title'] ?: $data['file_name'];
       $action['#url'] = Url::fromUri($data['file_uri']);
       $action['#attributes']['download'] = TRUE;
 

--- a/includes/theme.inc
+++ b/includes/theme.inc
@@ -102,6 +102,7 @@ function _gent_base_get_entity_reference_file_data(&$variables, $field) {
     $data['file_uri'] = $wrapper->getExternalUrl();
   }
   $data['file_type'] = $file_type;
+  $data['file_name'] = $file_name;
 
   return $data;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
CTA paragraph with a secondary document and with **an empty secondary title field** results in a 500 error. This is fixed in this update.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the gent_base CHANGELOG accordingly.
