### PR TITLE
SGD8-3103: Fix table Swiper on mobile 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,21 @@
 
 All Notable changes to `StadGent/drupal_theme_gent-base`.
 
+## [Unreleased]
+
+### Fixed
+
+- SGD8-3103: Fix table Swiper when table rows has colspan.
+
 ## [7.3.3]
+
+### Updated
 
 - SGD8-3097: Change renew link from <a> tag to <button> tag.
 
 ## [7.3.2]
+
+### Updated
 
 - SGD8-3068: Update the style guide version
 

--- a/source/js/table.bindings.js
+++ b/source/js/table.bindings.js
@@ -26,6 +26,38 @@
         return node;
       };
 
+      // SGD8-3103: Build a normalized grid that respects colspan
+      const buildGrid = (rows) => {
+        const grid = [];
+
+        rows.forEach((row, rowIndex) => {
+          if (!grid[rowIndex]) grid[rowIndex] = [];
+
+          let colIndex = 0;
+
+          row.querySelectorAll('th, td').forEach((cell) => {
+            // Skip already filled slots
+            while (grid[rowIndex][colIndex]) {
+              colIndex++;
+            }
+
+            const colspan = parseInt(cell.getAttribute('colspan')) || 1;
+
+            for (let i = 0; i < colspan; i++) {
+              grid[rowIndex][colIndex + i] = {
+                el: i === 0 ? cell.cloneNode(true) : null,
+                rowIndex,
+                isPlaceholder: i !== 0
+              };
+            }
+
+            colIndex += colspan;
+          });
+        });
+
+        return grid;
+      };
+
       tables.forEach((table) => {
         const rows = Array.from(table.querySelectorAll('tr'));
         if (rows.length === 0 || rows[0].children.length < 2) {
@@ -43,14 +75,16 @@
         wrapper.appendChild(tableWrapper);
         tableWrapper.appendChild(table);
 
-        // Group cells per column.
+        // SGD8-3103: Build columns via normalized grid
+        const grid = buildGrid(rows);
         const columns = [];
-        rows.forEach((row, rowIndex) => {
-          row.querySelectorAll('th, td').forEach((cell, colIndex) => {
+
+        grid.forEach((row) => {
+          row.forEach((cell, colIndex) => {
             if (!columns[colIndex]) {
               columns[colIndex] = [];
             }
-            columns[colIndex].push({el: cell.cloneNode(true), rowIndex});
+            columns[colIndex].push(cell);
           });
         });
 
@@ -64,9 +98,18 @@
         const fixedColumn = document.createElement('div');
         fixedColumn.classList.add('table-swiper__fixed-column');
         const fixedDl = document.createElement('dl');
-        columns[0].forEach(({el, rowIndex}) => {
-          fixedDl.appendChild(createCellRow(el, rowIndex));
+
+        columns[0].forEach(({el, rowIndex, isPlaceholder}) => {
+          if (isPlaceholder) {
+            const empty = document.createElement('dd');
+            empty.classList.add('cell-row', 'is-empty');
+            empty.dataset.rowIndex = rowIndex;
+            fixedDl.appendChild(empty);
+          } else {
+            fixedDl.appendChild(createCellRow(el, rowIndex));
+          }
         });
+
         fixedColumn.appendChild(fixedDl);
         swiperContainer.appendChild(fixedColumn);
 
@@ -80,9 +123,18 @@
           const slide = document.createElement('div');
           slide.classList.add('swiper-slide');
           const dl = document.createElement('dl');
-          column.forEach(({el, rowIndex}) => {
-            dl.appendChild(createCellRow(el, rowIndex));
+
+          column.forEach(({el, rowIndex, isPlaceholder}) => {
+            if (isPlaceholder) {
+              const empty = document.createElement('dd');
+              empty.classList.add('cell-row', 'is-empty');
+              empty.dataset.rowIndex = rowIndex;
+              dl.appendChild(empty);
+            } else {
+              dl.appendChild(createCellRow(el, rowIndex));
+            }
           });
+
           slide.appendChild(dl);
           swiperInner.appendChild(slide);
         });


### PR DESCRIPTION

## Description
When a table row has colspan ( cell spans across the whole row ) the Swiper on mobile becomes misaligned
see here for details 
https://district09.atlassian.net/browse/SGD8-3103
<img width="1267" height="588" alt="Screenshot 2026-04-21 154554" src="https://github.com/user-attachments/assets/1559af6d-85c3-4baa-9f17-b7cb4127e111" />

We now loop thro the table, find the cells with colspan, create empty cells before creating the Swiper to avoid misaligned table on mobile.

## Screenshots 
<img width="1393" height="796" alt="Screenshot 2026-04-21 154546" src="https://github.com/user-attachments/assets/ec98ece2-04b0-40ee-a27c-dfbf3e70fd80" />
:

## Result => empty cells are created to avoid misaligned table col/rows

<img width="545" height="428" alt="Screenshot 2026-04-22 090145" src="https://github.com/user-attachments/assets/a453756e-988c-4d94-8989-242e2b93adc5" />
<img width="1261" height="631" alt="Screenshot 2026-04-22 090156" src="https://github.com/user-attachments/assets/7d3c2a14-4d18-414a-9fdc-48b4c7f65d51" />


